### PR TITLE
Run Tests in Parallel

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -16,6 +16,9 @@ general:
     - "build/reports/tests" # preserve the generated HTML test reports
 
 test:
+  override:
+      - sh ./runTestParallel.sh:
+          parallel: true
   post:
     - mkdir -p $CIRCLE_TEST_REPORTS/junit/
     - find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;

--- a/runTestParallel.sh
+++ b/runTestParallel.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+echo "Total No.of nodes... ${CIRCLE_NODE_TOTAL}"
+echo "Current node index....${CIRCLE_NODE_INDEX}"
+
+testFiles=$(find src/test/groovy/org/gosulang/gradle -name '*.groovy' |
+sort | awk "NR % ${CIRCLE_NODE_TOTAL} == ${CIRCLE_NODE_INDEX}"|awk -F "/groovy/" '{print $2}'|awk -F "." '{print "--tests "$1}'|tr '/' '.')
+echo $testFiles
+./gradlew test $testFiles


### PR DESCRIPTION
This changes for to run tests in parallel for gradle-gosu-plugin project. The approach here is to split all tests equally based on the number of containers and run the subset of test on each container. 
One caveat for this approach is tests should be atomic, not dependent on other tests. 