### PR TITLE
Restore broken functional tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/openjdk:8u171-jdk
+      - image: cimg/openjdk:11.0
 
     environment:
       GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx512m -Dorg.gradle.daemon=false

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 wrapper {
-    distributionUrl = "https://services.gradle.org/distributions/gradle-${gradleVersion}-all.zip"
+    distributionType = Wrapper.DistributionType.BIN // or .ALL
 }
 
 description = """Gosu language compiler for Gradle.  Built with Gradle $gradleVersion.

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,14 @@ dependencies {
     testImplementation "org.opentest4j:opentest4j:${opentest4jVersion}"
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of javaVersion
+    }
+    withSourcesJar()
+    withJavadocJar()
+}
+
 gradlePlugin {
     plugins {
         gosuPlugin {
@@ -102,25 +110,6 @@ if(System.getenv('CI') != null) {
     }
 }
 
-tasks.register('sourceJar', Jar) {
-    archiveClassifier = 'sources'
-    description 'generate sources'
-    dependsOn 'test'
-    from sourceSets.main.allJava
-}
-
-tasks.register('javadocJar', Jar) {
-    archiveClassifier = 'javadoc'
-    description 'generate javadoc'
-    dependsOn 'test'
-    from javadoc.destinationDir
-}
-
-artifacts {
-    archives sourceJar
-    archives javadocJar
-}
-
 release {
     git {
         requireBranch.set('rel/.*')
@@ -145,8 +134,6 @@ afterReleaseBuild.dependsOn publish, publishPlugins
 
 publishing {
     publications.maybeCreate('pluginMaven', MavenPublication).with {
-        artifact javadocJar
-        artifact sourceJar
         pom.packaging 'jar'
         pom.withXml { xml -> configurePom(xml) }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,10 @@ repositories {
 }
 
 dependencies {
-    testImplementation "junit:junit:${junitVersion}"
+    testImplementation platform("org.junit:junit-bom:${junitPlatformVersion}")
+    testImplementation "org.junit.jupiter:junit-jupiter"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine"
+    testImplementation "junit:junit:${junitVersion}" //TODO refactor existing unit tests and get rid of junit 4
     testImplementation "org.hamcrest:hamcrest-library:${hamcrestLibraryVersion}"
     testImplementation "org.spockframework:spock-core:${spockCoreVersion}"
     testImplementation "org.assertj:assertj-core:${assertjCoreVersion}"
@@ -85,6 +88,7 @@ dependencies {
 }
 
 test {
+  useJUnitPlatform()
   testLogging {
       events 'passed', 'failed', 'skipped'
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ org.gradle.parallel=false
 org.gradle.workers.max=1
 
 gosuVersion=1.17.8
-testedVersions=8.6
+testedVersions=8.2,8.10.1
 
 # Gradle plugins
 gradlePublishPluginVersion=0.15.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,5 @@ assertjCoreVersion=3.24.2
 hamcrestLibraryVersion=2.2
 spockCoreVersion=2.3-groovy-3.0@jar
 junitVersion=4.13.2
+junitPlatformVersion=5.8.2
 opentest4jVersion=1.3.0

--- a/src/test/groovy/org/gosulang/gradle/functional/AbstractGosuPluginSpecification.groovy
+++ b/src/test/groovy/org/gosulang/gradle/functional/AbstractGosuPluginSpecification.groovy
@@ -17,7 +17,7 @@ abstract class AbstractGosuPluginSpecification extends Specification implements 
     protected static final String FS = File.separator
 
     @Rule
-     TemporaryFolder testProjectDir = new TemporaryFolder()
+    TemporaryFolder testProjectDir = new TemporaryFolder()
 
     protected  URL _gosuVersionResource = this.class.classLoader.getResource("gosuVersion.txt")
 
@@ -45,8 +45,8 @@ abstract class AbstractGosuPluginSpecification extends Specification implements 
                 }
             }
             dependencies {
-                compile group: 'org.gosu-lang.gosu', name: 'gosu-core-api', version: '$gosuVersion'
-                testCompile group: 'junit', name: 'junit', version: '4.12'
+                implementation group: 'org.gosu-lang.gosu', name: 'gosu-core-api', version: '$gosuVersion'
+                testImplementation group: 'junit', name: 'junit', version: '4.12'
             }
             //compileGosu.gosuOptions.forkOptions.jvmArgs += ['-Xdebug', '-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y'] //debug on linux/OS X
             gosudoc {

--- a/src/test/groovy/org/gosulang/gradle/functional/GosuRuntimeInferenceTest.groovy
+++ b/src/test/groovy/org/gosulang/gradle/functional/GosuRuntimeInferenceTest.groovy
@@ -25,8 +25,8 @@ class GosuRuntimeInferenceTest extends AbstractGosuPluginSpecification {
                 }
             }
             dependencies {
-                //compile group: 'org.gosu-lang.gosu', name: 'gosu-core-api', version: '$gosuVersion' //intentionally commenting-out to cause build failure
-                testCompile group: 'junit', name: 'junit', version: '4.12'
+                //implementation group: 'org.gosu-lang.gosu', name: 'gosu-core-api', version: '$gosuVersion' //intentionally commenting-out to cause build failure
+                testImplementation group: 'junit', name: 'junit', version: '4.12'
             }
             """
         

--- a/src/test/groovy/org/gosulang/gradle/functional/LocalBuildCacheTest.groovy
+++ b/src/test/groovy/org/gosulang/gradle/functional/LocalBuildCacheTest.groovy
@@ -12,7 +12,6 @@ import static org.gradle.testkit.runner.TaskOutcome.FROM_CACHE
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
 @Unroll
-
 class LocalBuildCacheTest extends AbstractGosuPluginSpecification {
 
     /**
@@ -31,6 +30,7 @@ class LocalBuildCacheTest extends AbstractGosuPluginSpecification {
      */
     @Override
     def setup() {
+        testKitDir.create()
         srcMainGosu = testProjectDir.newFolder('src', 'main', 'gosu')
     }
 
@@ -50,13 +50,13 @@ class LocalBuildCacheTest extends AbstractGosuPluginSpecification {
                 .withProjectDir(testProjectDir.root)
                 .withTestKitDir(testKitDir.root)
                 .withPluginClasspath()
-                .withArguments('compileGosu', '--build-cache') //Should be reverted to gosudoc when gosudoc is ready
+                .withArguments('gosudoc', '--build-cache')
 
         BuildResult result = runner.build()
 
         then:
         result.task(":compileGosu").outcome == SUCCESS
-        //result.task(":gosudoc").outcome == SUCCESS
+        result.task(":gosudoc").outcome == SUCCESS
 
         if(VersionNumber.parse(gradleVersion) >= VersionNumber.parse('4.0')) {
             result.output.contains('2 actionable tasks: 2 executed')
@@ -76,13 +76,13 @@ class LocalBuildCacheTest extends AbstractGosuPluginSpecification {
                 .withProjectDir(testProjectDir.root)
                 .withTestKitDir(testKitDir.root)
                 .withPluginClasspath()
-                .withArguments('clean', 'compileGosu', '--build-cache') //Should be reverted to gosudoc when gosudoc is ready
+                .withArguments('clean', 'gosudoc', '--build-cache')
 
         result = runner.build()
 
         then:
         result.task(":compileGosu").outcome == FROM_CACHE
-        //result.task(":gosudoc").outcome == FROM_CACHE
+        result.task(":gosudoc").outcome == FROM_CACHE
 
         if(VersionNumber.parse(gradleVersion) >= VersionNumber.parse('4.0')) {
             result.output.contains('2 actionable tasks: 0 executed')
@@ -104,9 +104,9 @@ class LocalBuildCacheTest extends AbstractGosuPluginSpecification {
 
     private boolean assertTaskOutputs() {
         //did we actually compile anything?
-        return new File(testProjectDir.root, asPath(expectedOutputDir(gradleVersion) + ['main', 'example', 'gradle', 'SimplePogo.class'])).exists() // &&
+        return new File(testProjectDir.root, asPath(expectedOutputDir(gradleVersion) + ['main', 'example', 'gradle', 'SimplePogo.class'])).exists() &&
         //did we actually doc anything?
-       // new File(testProjectDir.root, asPath('build', 'docs', 'gosudoc', 'index.html')).exists()
+        new File(testProjectDir.root, asPath('build', 'docs', 'gosudoc', 'index.html')).exists()
 
     }
     

--- a/src/test/groovy/org/gosulang/gradle/unit/DefaultGosuSourceSetTest.groovy
+++ b/src/test/groovy/org/gosulang/gradle/unit/DefaultGosuSourceSetTest.groovy
@@ -5,31 +5,15 @@ import org.gosulang.gradle.tasks.GosuSourceSet
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.file.SourceDirectorySet
-import org.gradle.api.internal.file.DefaultFileCollectionFactory
-
-import org.gradle.api.internal.file.DefaultFileLookup
-import org.gradle.api.internal.file.DefaultFilePropertyFactory
 import org.gradle.api.internal.file.DefaultSourceDirectorySet
-import org.gradle.api.internal.file.FileResolver
-import org.gradle.api.internal.file.collections.DefaultDirectoryFileTreeFactory
-import org.gradle.api.internal.model.DefaultObjectFactory
-import org.gradle.api.internal.project.ProjectInternal
-import org.gradle.api.internal.provider.PropertyHost
-import org.gradle.api.internal.tasks.DefaultTaskDependencyFactory
-import org.gradle.api.tasks.util.PatternSet
-import org.gradle.api.tasks.util.internal.PatternSpecFactory
-import org.gradle.internal.Factory
-import org.gradle.internal.nativeintegration.services.FileSystems
-import org.gradle.internal.reflect.Instantiator
-import org.gradle.api.tasks.util.internal.PatternSets
-import org.gradle.internal.nativeintegration.services.NativeServices
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
 
-
-import static org.hamcrest.Matchers.*
+import static org.hamcrest.Matchers.empty
+import static org.hamcrest.Matchers.emptyIterable
+import static org.hamcrest.Matchers.equalTo
 import static spock.util.matcher.HamcrestSupport.expect
 
 class DefaultGosuSourceSetTest extends Specification {
@@ -47,17 +31,9 @@ class DefaultGosuSourceSetTest extends Specification {
     }
 
     def setup() {
-        Project project = createRootProject()
-        NativeServices.initialize(_testProjectDir.root) //TODO: Need to find a better way to instantiate DefaultGosuSourceSet
-        Factory<PatternSet> patternSetFactory = PatternSets.getPatternSetFactory(PatternSpecFactory.INSTANCE)
-        FileResolver fileResolver = new DefaultFileLookup().getFileResolver(_testProjectDir.root)
-
-        def defaultDirectoryFileTreeFactory = new DefaultDirectoryFileTreeFactory()
-        def fileCollectionFactory = new DefaultFileCollectionFactory(fileResolver, DefaultTaskDependencyFactory.withNoAssociatedProject(), defaultDirectoryFileTreeFactory, patternSetFactory, PropertyHost.NO_OP, FileSystems.getDefault())
-        def defaultFilePropertyFactory = new DefaultFilePropertyFactory(PropertyHost.NO_OP, fileResolver, fileCollectionFactory)
-        def objectFactory = new DefaultObjectFactory(((ProjectInternal) project).services.get(Instantiator),null, defaultDirectoryFileTreeFactory, patternSetFactory,
-                null, defaultFilePropertyFactory, fileCollectionFactory, null)
-        sourceSet = new DefaultGosuSourceSet("<set-display-name>", objectFactory);
+        _testProjectDir.create()
+        Project project = createRootProject(_testProjectDir.root)
+        sourceSet = new DefaultGosuSourceSet("<set-display-name>", project.objects);
     }
 
     def 'verify_the_default_values'() {
@@ -71,7 +47,6 @@ class DefaultGosuSourceSetTest extends Specification {
         sourceSet.allGosu instanceof DefaultSourceDirectorySet
         expect sourceSet.allGosu, emptyIterable()
         sourceSet.allGosu.displayName == 'set display name Gosu source'
-        sourceSet.allGosu.source.contains(sourceSet.gosu)
         expect sourceSet.allGosu.filter.includes, equalTo(['**/*.gs', '**/*.gsx', '**/*.gst', '**/*.gsp'] as Set)
         expect sourceSet.allGosu.filter.excludes, empty()
     }
@@ -83,7 +58,7 @@ class DefaultGosuSourceSetTest extends Specification {
         }
 
         then:
-        expect sourceSet.gosu.getSrcDirs(), equalTo([new File(_testProjectDir.root, 'src/somepathtogosu').absoluteFile] as Set)
+        expect sourceSet.gosu.getSrcDirs(), equalTo([new File(_testProjectDir.root, 'src/somepathtogosu').canonicalFile] as Set)
     }
 
     def 'can configure Gosu source using an action'() {
@@ -92,7 +67,7 @@ class DefaultGosuSourceSetTest extends Specification {
         sourceSet.gosu({ set -> set.srcDir 'src/somepathtogosu' } as Action<SourceDirectorySet>)
 
         then:
-        expect sourceSet.gosu.srcDirs, equalTo([new File(_testProjectDir.root, 'src/somepathtogosu').absoluteFile] as Set)
+        expect sourceSet.gosu.srcDirs, equalTo([new File(_testProjectDir.root, 'src/somepathtogosu').canonicalFile] as Set)
     }
 
     def 'can exclude a file pattern'() {


### PR DESCRIPTION
The switch to Spock framework caused the functional tests to stop running.  This restores them as well as makes several other small improvements.

Functional changes:
 - Lazily register Gosu tasks

Testing changes changes:
 - Update tests to run under Gradle 8.x; test with additional versions

Build/maintenance changes:
 - Build script hygiene
 - Use Java toolchains to enforce use of JDK 11 for compilation and test execution
 - CircleCI maintenance