### PR TITLE
Issue #61: Use version catalog to specify project and build dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ import java.nio.charset.StandardCharsets
 plugins {
     id 'com.gradle.plugin-publish' version "${gradlePublishPluginVersion}"
     id 'net.researchgate.release' version "${researchgateReleaseGradlePluginVersion}"
+    id "org.gradlex.reproducible-builds" version "${reproducibleBuildsPluginVersion}"
     id 'groovy'
     id 'java-gradle-plugin'
     id 'maven-publish'

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,7 @@ testedVersions=8.2,8.10.1
 # Gradle plugins
 gradlePublishPluginVersion=0.15.0
 researchgateReleaseGradlePluginVersion=3.0.2
+reproducibleBuildsPluginVersion=1.0
 
 # For docker container
 javaVersion=11


### PR DESCRIPTION
Optional change.  Removes custom properties for version definition and moves to the default version catalog.

The typesafe generated references in the buildscript are nice to work with in IntelliJ.