### PR TITLE
Fix #57: Make build artifacts bitwise reproducible

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ import java.nio.charset.StandardCharsets
 plugins {
     id 'com.gradle.plugin-publish' version "${gradlePublishPluginVersion}"
     id 'net.researchgate.release' version "${researchgateReleaseGradlePluginVersion}"
+    id "org.gradlex.reproducible-builds" version "${reproducibleBuildsPluginVersion}"
     id 'groovy'
     id 'java-gradle-plugin'
     id 'maven-publish'

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,7 @@ testedVersions=8.2,8.10.1
 # Gradle plugins
 gradlePublishPluginVersion=0.15.0
 researchgateReleaseGradlePluginVersion=3.0.2
+reproducibleBuildsPluginVersion=1.0
 
 # For docker container
 javaVersion=11


### PR DESCRIPTION
Verified locally using `$ ./gradlew clean build pTML`.

Results look good (note timestamps are all identical):

```
$ zipinfo ~/.m2/repository/org/gosu-lang/gosu/gradle-gosu-plugin/8.1.3-SNAPSHOT/gradle-gosu-plugin-8.1.3-SNAPSHOT.jar 
Archive:  ~/.m2/repository/org/gosu-lang/gosu/gradle-gosu-plugin/8.1.3-SNAPSHOT/gradle-gosu-plugin-8.1.3-SNAPSHOT.jar
Zip file size: 46701 bytes, number of entries: 33
drwxr-xr-x  2.0 unx        0 b- defN 80-Feb-01 00:00 META-INF/
-rw-r--r--  2.0 unx       25 b- defN 80-Feb-01 00:00 META-INF/MANIFEST.MF
drwxr-xr-x  2.0 unx        0 b- defN 80-Feb-01 00:00 org/
drwxr-xr-x  2.0 unx        0 b- defN 80-Feb-01 00:00 org/gosulang/
drwxr-xr-x  2.0 unx        0 b- defN 80-Feb-01 00:00 org/gosulang/gradle/
-rw-r--r--  2.0 unx    13956 b- defN 80-Feb-01 00:00 org/gosulang/gradle/GosuBasePlugin.class
-rw-r--r--  2.0 unx     5225 b- defN 80-Feb-01 00:00 org/gosulang/gradle/GosuPlugin.class
drwxr-xr-x  2.0 unx        0 b- defN 80-Feb-01 00:00 org/gosulang/gradle/tasks/
-rw-r--r--  2.0 unx     3983 b- defN 80-Feb-01 00:00 org/gosulang/gradle/tasks/DefaultGosuSourceSet.class
-rw-r--r--  2.0 unx     2569 b- defN 80-Feb-01 00:00 org/gosulang/gradle/tasks/GosuRuntime$1.class
-rw-r--r--  2.0 unx     7273 b- defN 80-Feb-01 00:00 org/gosulang/gradle/tasks/GosuRuntime.class
...
```