### PR TITLE
Fix Issue #75: Remove upfront repository check in GosuRuntime

### DIFF
--- a/src/main/java/org/gosulang/gradle/tasks/GosuRuntime.java
+++ b/src/main/java/org/gosulang/gradle/tasks/GosuRuntime.java
@@ -57,10 +57,6 @@ public class GosuRuntime {
   }
 
   private FileCollection doInfer(Iterable<File> classpath) {
-    if (_project.getRepositories().isEmpty()) {
-      throw new GradleException("Cannot infer Gosu classpath because no repository is declared in " + _project);
-    }
-
     File gosuCoreApiJar = findGosuJar(classpath, "core-api");
 
     if (gosuCoreApiJar == null) {

--- a/src/test/groovy/org/gosulang/gradle/functional/GosuRuntimeInferenceTest.groovy
+++ b/src/test/groovy/org/gosulang/gradle/functional/GosuRuntimeInferenceTest.groovy
@@ -5,10 +5,14 @@ import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.UnexpectedBuildSuccess
 import spock.lang.Unroll
 
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
 @Unroll
 class GosuRuntimeInferenceTest extends AbstractGosuPluginSpecification {
 
     File simplePogo
+    File srcMainGosu
+    File settingsFile
     
     def 'Build throws when gosu-core-api jar is not declared as a dependency [Gradle #gradleVersion]'() {
         given:
@@ -54,5 +58,167 @@ class GosuRuntimeInferenceTest extends AbstractGosuPluginSpecification {
         gradleVersion << gradleVersionsToTest
     }
 
+    def 'Repository declared in settings.gradle via dependencyResolutionManagement is recognized [Gradle #gradleVersion]'() {
+        given:
+        // Create settings.gradle with dependencyResolutionManagement
+        settingsFile = testProjectDir.newFile('settings.gradle')
+        settingsFile << """
+            dependencyResolutionManagement {
+                repositories {
+                    mavenLocal()
+                    mavenCentral()
+                    maven {
+                        url 'https://central.sonatype.com/repository/maven-snapshots/'
+                    }
+                }
+            }
+
+            rootProject.name = 'test-settings-repo'
+        """
+
+        // Create build.gradle WITHOUT repositories block
+        buildScript << """
+            plugins {
+                id 'org.gosu-lang.gosu'
+            }
+
+            // Note: NO repositories block here - all repositories in settings.gradle
+
+            dependencies {
+                implementation group: 'org.gosu-lang.gosu', name: 'gosu-core-api', version: '$gosuVersion'
+                testImplementation group: 'junit', name: 'junit', version: '4.12'
+            }
+        """
+
+        srcMainGosu = testProjectDir.newFolder('src', 'main', 'gosu')
+        simplePogo = new File(srcMainGosu, 'SimplePogo.gs')
+        simplePogo << """
+            public class SimplePogo {
+                function sayHello() : String {
+                    return "Hello from Gosu"
+                }
+            }
+        """
+
+        when:
+        GradleRunner runner = GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withPluginClasspath()
+                .withArguments('compileGosu', '-is')
+                .withGradleVersion(gradleVersion)
+                .forwardOutput()
+
+        BuildResult result = runner.build()
+
+        then:
+        result.task(":compileGosu").outcome == SUCCESS
+        new File(testProjectDir.root, asPath(expectedOutputDir(gradleVersion) + ['main', 'SimplePogo.class'])).exists()
+        result.output.contains('Initializing gosuc compiler')
+
+        where:
+        gradleVersion << gradleVersionsToTest
+    }
+
+    def 'Build fails when no repositories are declared anywhere [Gradle #gradleVersion]'() {
+        given:
+        // Create settings.gradle WITHOUT repositories
+        settingsFile = testProjectDir.newFile('settings.gradle')
+        settingsFile << """
+            rootProject.name = 'test-no-repo'
+        """
+
+        // Create build.gradle WITHOUT repositories block
+        buildScript << """
+            plugins {
+                id 'org.gosu-lang.gosu'
+            }
+
+            // No repositories block
+
+            dependencies {
+                implementation group: 'org.gosu-lang.gosu', name: 'gosu-core-api', version: '$gosuVersion'
+            }
+        """
+
+        srcMainGosu = testProjectDir.newFolder('src', 'main', 'gosu')
+        simplePogo = new File(srcMainGosu, 'SimplePogo.gs')
+        simplePogo << """
+            public class SimplePogo {}
+        """
+
+        when:
+        GradleRunner runner = GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withPluginClasspath()
+                .withArguments('compileGosu', '-is')
+                .withGradleVersion(gradleVersion)
+                .forwardOutput()
+
+        BuildResult result = runner.buildAndFail()
+
+        then:
+        // With no repositories, Gradle's dependency resolution will fail
+        // The error message varies by Gradle version but typically mentions "no repositories"
+        result.output.contains('gosu-doc') || result.output.contains('Could not resolve')
+
+        where:
+        gradleVersion << gradleVersionsToTest
+    }
+
+    def 'Repositories in both settings and project are recognized [Gradle #gradleVersion]'() {
+        given:
+        // Create settings.gradle with one repository
+        settingsFile = testProjectDir.newFile('settings.gradle')
+        settingsFile << """
+            dependencyResolutionManagement {
+                repositories {
+                    mavenLocal()
+                }
+            }
+
+            rootProject.name = 'test-both-repos'
+        """
+
+        // Create build.gradle with additional repositories
+        buildScript << """
+            plugins {
+                id 'org.gosu-lang.gosu'
+            }
+
+            repositories {
+                mavenCentral()
+                maven {
+                    url 'https://central.sonatype.com/repository/maven-snapshots/'
+                }
+            }
+
+            dependencies {
+                implementation group: 'org.gosu-lang.gosu', name: 'gosu-core-api', version: '$gosuVersion'
+            }
+        """
+
+        srcMainGosu = testProjectDir.newFolder('src', 'main', 'gosu')
+        simplePogo = new File(srcMainGosu, 'SimplePogo.gs')
+        simplePogo << """
+            public class SimplePogo {}
+        """
+
+        when:
+        GradleRunner runner = GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withPluginClasspath()
+                .withArguments('compileGosu', '-is')
+                .withGradleVersion(gradleVersion)
+                .forwardOutput()
+
+        BuildResult result = runner.build()
+
+        then:
+        result.task(":compileGosu").outcome == SUCCESS
+        new File(testProjectDir.root, asPath(expectedOutputDir(gradleVersion) + ['main', 'SimplePogo.class'])).exists()
+
+        where:
+        gradleVersion << gradleVersionsToTest
+    }
 
 }

--- a/src/test/groovy/org/gosulang/gradle/unit/GosuRuntimeTest.groovy
+++ b/src/test/groovy/org/gosulang/gradle/unit/GosuRuntimeTest.groovy
@@ -14,17 +14,6 @@ class GosuRuntimeTest extends Specification {
         project.pluginManager.apply(GosuBasePlugin)
     }
 
-    def 'inference fails if no repository declared'() {
-        when:
-        def gosuClasspath = project.gosuRuntime.inferGosuClasspath([new File('other.jar'), new File('gosu-core-api-1.8.jar')])
-        gosuClasspath.call().files
-
-        then:
-        GradleException e = thrown()
-        System.out.println(e.message)
-        e.message.equals('Cannot infer Gosu classpath because no repository is declared in ' + project)
-    }
-
     def 'test to find Gosu Jars on class path'() {
         when:
         def core = project.gosuRuntime.findGosuJar([new File('other.jar'), new File('gosu-core-1.7.jar'), new File('gosu-core-api-1.8.jar')], 'core')


### PR DESCRIPTION
The previous implementation checked if repositories were declared before attempting to infer the Gosu classpath. However, this check only looked at project-level repositories and failed when repositories were configured via dependencyResolutionManagement in settings.gradle (Gradle 6.8+).

Since there's no way to access settings-level repositories from a project plugin at runtime (Gradle.getSettings() doesn't exist in the Gradle API), the solution is to remove the upfront check entirely. When repositories are configured via settings.gradle, they're automatically available for dependency resolution. If no repositories are available from any source, Gradle's own dependency resolution will fail with a clear error message.

This approach follows the pattern from PR #69 and ensures the plugin works correctly with modern Gradle project structures.

Added functional tests to verify:
- Repositories declared only in settings.gradle work correctly
- Build fails appropriately when no repositories are declared anywhere
- Mixed repository configuration (both settings and project) works

🤖 Generated with [Claude Code](https://claude.com/claude-code)