### PR TITLE
Make the per-source-set resources filter configuration-cache compatible (#68)

### DIFF
--- a/src/main/java/org/gosulang/gradle/GosuBasePlugin.java
+++ b/src/main/java/org/gosulang/gradle/GosuBasePlugin.java
@@ -9,12 +9,15 @@ import org.gosulang.gradle.tasks.compile.GosuCompile;
 import org.gosulang.gradle.tasks.gosudoc.GosuDoc;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.FileTreeElement;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.tasks.DefaultSourceSetOutput;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.Convention;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.reporting.ReportingExtension;
+import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.compile.AbstractCompile;
@@ -22,6 +25,7 @@ import org.gradle.internal.Cast;
 
 import javax.inject.Inject;
 import java.io.File;
+import java.io.Serializable;
 
 import static org.gosulang.gradle.tasks.Util.javaPluginExtension;
 
@@ -69,7 +73,17 @@ public class GosuBasePlugin implements Plugin<Project> {
       sourceSetConvention.getPlugins().put("gosu", gosuSourceSet);
   //    sourceSet.getExtensions().add(SourceDirectorySet.class, "gosu", gosuSourceSet.getGosu()); //alternative but it's not working
       gosuSourceSet.getGosu().srcDir("src/" + sourceSet.getName() + "/gosu");
-      sourceSet.getResources().getFilter().exclude(element -> gosuSourceSet.getGosu().contains(element.getFile()));
+      // Exclude gosu sources from this source set's resources with a *serializable* Spec, so the filter — and
+      // therefore every consumer's ProcessResources task — is configuration-cache compatible. The
+      // (Spec & Serializable) intersection cast produces a serializable lambda using only public Java/Gradle
+      // API; it is exactly what Gradle's own GroovyBasePlugin/ScalaBasePlugin do via the internal
+      // SerializableLambdas.spec (which a community plugin must not depend on). Capture a FileCollection view of
+      // the gosu sources (serialized via the configuration cache's file-collection codec), NOT the
+      // DefaultGosuSourceSet graph — capturing the latter was the dominant CC hazard this plugin imposed on
+      // consumers. See #68.
+      final FileCollection gosuSourceFiles = gosuSourceSet.getGosu();
+      sourceSet.getResources().getFilter().exclude(
+          (Spec<FileTreeElement> & Serializable) element -> gosuSourceFiles.contains(element.getFile()));
       sourceSet.getAllSource().source(gosuSourceSet.getGosu());
       configureGosuCompile(sourceSet, gosuSourceSet);
     });

--- a/src/test/groovy/org/gosulang/gradle/functional/ConfigurationCacheResourcesTest.groovy
+++ b/src/test/groovy/org/gosulang/gradle/functional/ConfigurationCacheResourcesTest.groovy
@@ -1,0 +1,69 @@
+package org.gosulang.gradle.functional
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import spock.lang.Unroll
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+/**
+ * Guards the configuration-cache compatibility of the resources filter that {@code GosuBasePlugin} installs on
+ * every source set (issue #68).
+ *
+ * <p>Before the fix, the resources {@code exclude} was a plain (non-serializable) lambda capturing the gosu
+ * {@code SourceDirectorySet}; it serialized into every consumer's {@code ProcessResources} task and produced the
+ * dominant block of configuration-cache problems this plugin imposed on consumers. The fix wraps it in
+ * {@code SerializableLambdas.spec(...)} capturing only a {@code FileCollection}, mirroring Gradle's own
+ * {@code GroovyBasePlugin}/{@code ScalaBasePlugin}.</p>
+ *
+ * <p>We request {@code processResources} specifically: it pulls {@code ProcessResources} (the task that carried
+ * the captured filter) into the task graph WITHOUT pulling in {@code compileGosu}, whose own configuration-cache
+ * hazards are addressed separately. Running under {@code STABLE_CONFIGURATION_CACHE} makes any CC problem fail
+ * the build.</p>
+ */
+@Unroll
+class ConfigurationCacheResourcesTest extends AbstractGosuPluginSpecification {
+
+    File srcMainGosu
+    File srcMainResources
+
+    @Override
+    def setup() {
+        srcMainGosu = testProjectDir.newFolder('src', 'main', 'gosu')
+        srcMainResources = testProjectDir.newFolder('src', 'main', 'resources')
+    }
+
+    def 'processResources is configuration-cache compatible [Gradle #gradleVersion]'() {
+        given:
+        buildScript << getBasicBuildScriptForTesting()
+        testProjectDir.newFile('settings.gradle') << 'enableFeaturePreview "STABLE_CONFIGURATION_CACHE"'
+
+        and: 'a gosu source file (so the resources filter has gosu sources to exclude) and a real resource'
+        File pogo = new File(srcMainGosu, asPath('example', 'gradle', 'SimplePogo.gs'))
+        pogo.getParentFile().mkdirs()
+        pogo << 'package example.gradle\n\nclass SimplePogo {}'
+        new File(srcMainResources, 'application.properties') << 'foo=bar'
+
+        when: 'the configuration cache entry is stored'
+        GradleRunner runner = GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withPluginClasspath()
+                .withArguments('processResources', '--configuration-cache')
+                .withGradleVersion(gradleVersion)
+        BuildResult storeResult = runner.build()
+
+        then: 'the store succeeds with no CC problems (strict mode would fail the build otherwise)'
+        storeResult.task(':processResources').outcome == SUCCESS
+        storeResult.output.contains('Configuration cache entry stored.')
+
+        when: 'the build runs again'
+        BuildResult reuseResult = runner.build()
+
+        then: 'the entry round-trips and is reused'
+        reuseResult.output.contains('Reusing configuration cache.')
+        reuseResult.output.contains('Configuration cache entry reused.')
+
+        where:
+        gradleVersion << gradleVersionsToTest
+    }
+}


### PR DESCRIPTION
tl;dr calling `gosuSourceSet.getGosu()` from within a lambda is not configuration-cache compatible; extracting it.

GosuBasePlugin installed each source set's resources `exclude` as a plain lambda that captured the gosu SourceDirectorySet (via `gosuSourceSet.getGosu()`), which serialized the non-serializable DefaultGosuSourceSet graph into every consumer's ProcessResources task — the dominant block of configuration-cache problems this plugin imposes on consumers.

Capture the gosu sources as a local FileCollection and install the exclude as a serializable Spec via the `(Spec<FileTreeElement> & Serializable)` intersection cast. This uses public Java/Gradle API only and is semantically identical to what Gradle's own GroovyBasePlugin/ScalaBasePlugin do via the internal SerializableLambdas.spec helper (which a community plugin must not depend on). It stays Gradle 8.6-compatible, which matters because consumers run the plugin on Gradle 8.6.

Adds ConfigurationCacheResourcesTest, which requests `processResources` under STABLE_CONFIGURATION_CACHE and asserts the CC entry is stored then reused. The test was verified to FAIL on the previous plain-lambda form and PASS with this fix, so it genuinely guards the regression.

Scope: this is the isolated, low-risk part of #68. The GosuCompile / gosudoc configuration-cache work — and the orderClasspath deprecation (#84) — is left for follow-ups, to avoid colliding with in-flight incremental-gosuc changes.