### PR TITLE
Test against Gradle 8.14.5 (#88)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ org.gradle.parallel=false
 org.gradle.workers.max=1
 
 gosuVersion=1.17.8
-testedVersions=8.2,8.10.1
+testedVersions=8.2,8.10.1,8.14.5
 
 # Gradle plugins
 gradlePublishPluginVersion=1.3.0


### PR DESCRIPTION
Add Gradle 8.14.5 to `testedVersions` so the functional-test matrix — iterated on CI via GradleRunner#withGradleVersion — exercises the plugin on a current 8.14.x release alongside 8.2 and 8.10.1.  Closes #88.

Note: this may surface pre-existing incompatibilities to address as follow-ups. The plugin still uses the deprecated `Convention` API reflectively (InvokerHelper.getProperty(sourceSet, "convention"), removed in Gradle 9.0), and some functional tests enable the `STABLE_CONFIGURATION_CACHE` feature preview; both may warn or fail on newer Gradle.