### PR TITLE
Refactor for minimal configuration cache compatibility

### DIFF
--- a/src/main/java/org/gosulang/gradle/GosuBasePlugin.java
+++ b/src/main/java/org/gosulang/gradle/GosuBasePlugin.java
@@ -9,10 +9,11 @@ import org.gosulang.gradle.tasks.compile.GosuCompile;
 import org.gosulang.gradle.tasks.gosudoc.GosuDoc;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTreeElement;
 import org.gradle.api.file.SourceDirectorySet;
-import org.gradle.api.internal.tasks.DefaultSourceSetOutput;
+import org.gradle.api.logging.LogLevel;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.Convention;
 import org.gradle.api.plugins.JavaBasePlugin;
@@ -21,10 +22,8 @@ import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.compile.AbstractCompile;
-import org.gradle.internal.Cast;
 
 import javax.inject.Inject;
-import java.io.File;
 import java.io.Serializable;
 
 import static org.gosulang.gradle.tasks.Util.javaPluginExtension;
@@ -61,6 +60,26 @@ public class GosuBasePlugin implements Plugin<Project> {
    * Sets the gosuClasspath property for all GosuCompile tasks: compileGosu and compileTestGosu
    */
   private void configureCompileDefaults() {
+    // Convention mapping defers evaluation of inferGosuClasspath() to first access (task execution on
+    // non-CC builds; CC-store time on CC builds, when BeanPropertyWriter serialises the task graph).
+    // This matches the pattern used by GroovyBasePlugin and ScalaBasePlugin.
+    //
+    // IMPORTANT – the backing field in GosuCompile/GosuDoc MUST be named 'gosuClasspath' (no
+    // underscore prefix). Gradle's CC BeanPropertyWriter looks up convention mappings by the
+    // backing-field name; an underscore-prefixed name produces a key mismatch so the convention
+    // is never found, CC stores null for the field, and gosuClasspath is empty on CC reuse.
+    // Fixed upstream in Gradle 8.8 via gradle/gradle#28248 (ConfigurableFileCollection now
+    // wires its convention directly, bypassing the field-name lookup); required for Gradle ≤ 8.7.
+    //
+    // Using CFC#from(Callable) here instead (PR #93) causes CC to attempt to serialise the
+    // lambda at store time; when that fails the property is left unconfigured, producing a
+    // WorkValidationException before the task action runs.
+    //
+    // TODO: once minimum Gradle is 8.8, drop convention mapping here and in configureGosuDoc()
+    // and replace with: gosuCompile.getGosuClasspath().convention(_project.getObjects()
+    //   .fileCollection().from((Callable) () -> _gosuRuntime.inferGosuClasspath(...))).
+    // CFC#convention(Callable) was introduced in Gradle 8.8 (gradle/gradle#28248); it wires
+    // the convention directly on the CFC and is fully CC-safe without the field-name constraint.
     _project.getTasks().withType(GosuCompile.class, gosuCompile ->
         gosuCompile.getConventionMapping().map("gosuClasspath", () -> _gosuRuntime.inferGosuClasspath(gosuCompile.getClasspath())));
   }
@@ -96,17 +115,22 @@ public class GosuBasePlugin implements Plugin<Project> {
    */
   private void configureGosuCompile(SourceSet sourceSet, GosuSourceSet gosuSourceSet) {
     String compileTaskName = sourceSet.getCompileTaskName("gosu");
-    TaskProvider<? extends AbstractCompile> gosuCompile = _project.getTasks().register(compileTaskName, GosuCompile.class);
+    TaskProvider<GosuCompile> gosuCompile = _project.getTasks().register(compileTaskName, GosuCompile.class);
     configureForSourceSet(sourceSet, gosuSourceSet.getGosu(), gosuCompile, _project);
-    gosuCompile.configure(t -> t.dependsOn(sourceSet.getCompileJavaTaskName()));
-    gosuCompile.configure(t -> t.setSource((Object) gosuSourceSet.getGosu())); // Gradle 4.0 overloads setSource; must upcast to Object for backwards compatibility
+    gosuCompile.configure(t -> {
+      t.dependsOn(sourceSet.getCompileJavaTaskName());
+      t.getSourceRoots().from(gosuSourceSet.getGosu().getSourceDirectories());
+      t.setSource((Object) gosuSourceSet.getGosu()); // Gradle 4.0 overloads setSource; must upcast to Object for backwards compatibility
+    });
     _project.getTasks().getByName(sourceSet.getClassesTaskName()).dependsOn(compileTaskName);
   }
 
   private void configureGosuDoc() {
+    // Same convention-mapping pattern as configureCompileDefaults(); see that comment for rationale.
     _project.getTasks().withType(GosuDoc.class, gosudoc -> {
+      gosudoc.getLogging().captureStandardOutput(LogLevel.INFO);
       gosudoc.getConventionMapping().map("gosuClasspath", () -> _gosuRuntime.inferGosuClasspath(gosudoc.getClasspath()));
-      gosudoc.getConventionMapping().map("destinationDir", () -> new File(javaPluginExtension(_project).getDocsDir().get().getAsFile(), "gosudoc"));
+      gosudoc.getDestinationDir().convention(javaPluginExtension(_project).getDocsDir().map(d -> d.dir("gosudoc")));
       gosudoc.getConventionMapping().map("title", () -> _project.getExtensions().getByType(ReportingExtension.class).getApiDocTitle());
       //gosudoc.getConventionMapping().map("windowTitle", (Callable<Object>) () -> _project.getExtensions().getByType(ReportingExtension.class).getApiDocTitle());
     });
@@ -124,8 +148,7 @@ public class GosuBasePlugin implements Plugin<Project> {
  private static void configureOutputDirectoryForSourceSet(final SourceSet sourceSet, final SourceDirectorySet sourceDirectorySet, final Project target, TaskProvider<? extends AbstractCompile> compileTask) {
     final String sourceSetChildPath = "classes/" + sourceDirectorySet.getName() + "/" + sourceSet.getName();
     sourceDirectorySet.getDestinationDirectory().convention(target.getLayout().getBuildDirectory().dir(sourceSetChildPath));
-    DefaultSourceSetOutput sourceSetOutput = Cast.cast(DefaultSourceSetOutput.class, sourceSet.getOutput());
-    sourceSetOutput.getClassesDirs().from(sourceDirectorySet.getDestinationDirectory()).builtBy(compileTask);
+    ((ConfigurableFileCollection) sourceSet.getOutput().getClassesDirs()).from(sourceDirectorySet.getDestinationDirectory()).builtBy(compileTask);
     sourceDirectorySet.compiledBy(compileTask, AbstractCompile::getDestinationDirectory);
   }
 

--- a/src/main/java/org/gosulang/gradle/tasks/GosuRuntime.java
+++ b/src/main/java/org/gosulang/gradle/tasks/GosuRuntime.java
@@ -1,6 +1,5 @@
 package org.gosulang.gradle.tasks;
 
-import groovy.lang.Closure;
 import org.gradle.api.Buildable;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
@@ -37,23 +36,19 @@ public class GosuRuntime {
    * @param classpath a classpath containing a 'gosu-core-api' Jar
    * @return a classpath containing a corresponding 'gosu-doc' Jar and its dependencies
    */
-  public Closure<FileCollection> inferGosuClasspath(final Iterable<File> classpath) {
-    return new Closure<FileCollection>(this, this) {
-      private FileCollection resolved;
-
-      public FileCollection doCall(Object ignore) {
-        ConfigurableFileCollection fileCollection = _project.files((Callable<FileCollection>) () -> {
-          if (resolved == null) {
-            resolved = doInfer(classpath);
-          }
-          return resolved;
-        });
-        if (classpath instanceof Buildable) {
-          fileCollection.builtBy(((Buildable) classpath).getBuildDependencies());
-        }
-        return fileCollection;
+  public FileCollection inferGosuClasspath(final FileCollection classpath) {
+    ConfigurableFileCollection result = _project.getObjects().fileCollection();
+    final FileCollection[] resolved = {null};
+    result.from((Callable<FileCollection>) () -> {
+      if (resolved[0] == null) {
+        resolved[0] = doInfer(classpath);
       }
-    };
+      return resolved[0];
+    });
+    if (classpath instanceof Buildable) {
+      result.builtBy(((Buildable) classpath).getBuildDependencies());
+    }
+    return result;
   }
 
   private FileCollection doInfer(Iterable<File> classpath) {

--- a/src/main/java/org/gosulang/gradle/tasks/InfersGosuRuntime.java
+++ b/src/main/java/org/gosulang/gradle/tasks/InfersGosuRuntime.java
@@ -1,12 +1,12 @@
 package org.gosulang.gradle.tasks;
 
-import groovy.lang.Closure;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 
 public interface InfersGosuRuntime {
 
-  Closure<FileCollection> getGosuClasspath();
+  ConfigurableFileCollection getGosuClasspath();
 
-  void setGosuClasspath(Closure<FileCollection> gosuClasspathClosure);
+  void setGosuClasspath(FileCollection gosuClasspath);
 
 }

--- a/src/main/java/org/gosulang/gradle/tasks/compile/CommandLineGosuCompiler.java
+++ b/src/main/java/org/gosulang/gradle/tasks/compile/CommandLineGosuCompiler.java
@@ -2,12 +2,13 @@ package org.gosulang.gradle.tasks.compile;
 
 import org.apache.tools.ant.taskdefs.condition.Os;
 import org.gosulang.gradle.tasks.Util;
-import org.gradle.api.Project;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.compile.BaseForkOptions;
+import org.gradle.process.ExecOperations;
 import org.gradle.process.ExecResult;
 import org.gradle.process.JavaExecSpec;
 import org.gradle.util.GUtil;
@@ -23,17 +24,21 @@ import java.util.List;
 
 public class CommandLineGosuCompiler implements GosuCompiler<GosuCompileSpec> {
   private static final Logger LOGGER = Logging.getLogger(CommandLineGosuCompiler.class);
-  
-  private final Project _project;
+
+  private final ExecOperations _execOperations;
+  private final ObjectFactory _objectFactory;
   private final GosuCompileSpec _spec;
   private final String _projectName;
-  
-  public CommandLineGosuCompiler(Project project, GosuCompileSpec spec, String projectName ) {
-    _project = project;
+  private final File _projectDir;
+
+  public CommandLineGosuCompiler(ExecOperations execOperations, ObjectFactory objectFactory, GosuCompileSpec spec, String projectName, File projectDir) {
+    _execOperations = execOperations;
+    _objectFactory = objectFactory;
     _spec = spec;
     _projectName = projectName;
+    _projectDir = projectDir;
   }
-  
+
   @Override
   public WorkResult execute( GosuCompileSpec spec ) {
     String startupMsg = "Initializing gosuc compiler";
@@ -52,17 +57,17 @@ public class CommandLineGosuCompiler implements GosuCompiler<GosuCompileSpec> {
       LOGGER.error("Error creating argfile with gosuc arguments");
       throw new GosuCompilationFailedException(e);
     }
-    
+
     ByteArrayOutputStream stdout = new ByteArrayOutputStream();
     ByteArrayOutputStream stderr = new ByteArrayOutputStream();
 
-    ExecResult result = _project.javaexec(javaExecSpec -> {
-      FileCollection gosuClasspathJars =  spec.getGosuClasspath().call();
+    ExecResult result = _execOperations.javaexec(javaExecSpec -> {
+      FileCollection gosuClasspathJars = spec.getGosuClasspath();
       if (!JavaVersion.current().isJava11Compatible()) { //if it is not java 11
-        gosuClasspathJars = gosuClasspathJars.plus(_project.files(Util.findToolsJar()));
+        gosuClasspathJars = gosuClasspathJars.plus(_objectFactory.fileCollection().from(Util.findToolsJar()));
       }
 
-      javaExecSpec.setWorkingDir((Object) _project.getProjectDir()); // Gradle 4.0 overloads ProcessForkOptions#setWorkingDir; must upcast to Object for backwards compatibility
+      javaExecSpec.setWorkingDir((Object) _projectDir); // Gradle 4.0 overloads ProcessForkOptions#setWorkingDir; must upcast to Object for backwards compatibility
       setJvmArgs(javaExecSpec, _spec.getGosuCompileOptions().getForkOptions());
       javaExecSpec.getMainClass().set("gw.lang.gosuc.cli.CommandLineCompiler");
       javaExecSpec.setClasspath(gosuClasspathJars)
@@ -115,7 +120,7 @@ public class CommandLineGosuCompiler implements GosuCompiler<GosuCompileSpec> {
 
     spec.setJvmArgs((Iterable<?>) args); // Gradle 4.0 overloads JavaForkOptions#setJvmArgs; must upcast to Iterable<?> for backwards compatibility
   }
-  
+
   private File createArgFile(GosuCompileSpec spec) throws IOException {
     File tempFile = File.createTempFile(CommandLineGosuCompiler.class.getName(), "arguments", spec.getTempDir());
 
@@ -124,7 +129,7 @@ public class CommandLineGosuCompiler implements GosuCompiler<GosuCompileSpec> {
     if(spec.getGosuCompileOptions().isCheckedArithmetic()) {
       fileOutput.add("-checkedArithmetic");
     }
-    
+
     // The classpath used to initialize Gosu; CommandLineCompiler will supplement this with the JRE jars
     fileOutput.add("-classpath");
     fileOutput.add(String.join(File.pathSeparator, GUtil.asPath(spec.getClasspath())));
@@ -152,7 +157,7 @@ public class CommandLineGosuCompiler implements GosuCompiler<GosuCompileSpec> {
       fileOutput.add("-maxerrs");
       fileOutput.add(spec.getGosuCompileOptions().getMaxErrs().toString());
     }
-    
+
     for(File sourceFile : spec.getSource()) {
       fileOutput.add(sourceFile.getPath());
     }

--- a/src/main/java/org/gosulang/gradle/tasks/compile/DefaultGosuCompileSpec.java
+++ b/src/main/java/org/gosulang/gradle/tasks/compile/DefaultGosuCompileSpec.java
@@ -1,6 +1,5 @@
 package org.gosulang.gradle.tasks.compile;
 
-import groovy.lang.Closure;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.compile.CompileOptions;
 
@@ -12,7 +11,7 @@ import java.util.List;
 public class DefaultGosuCompileSpec implements GosuCompileSpec {
 
   private GosuCompileOptions _gosuCompileOptions;
-  private transient Closure<FileCollection> _gosuClasspath;
+  private FileCollection _gosuClasspath;
   private FileCollection _srcDirSet;
 
   @Override
@@ -26,13 +25,13 @@ public class DefaultGosuCompileSpec implements GosuCompileSpec {
   }
 
   @Override
-  public Closure<FileCollection> getGosuClasspath() {
+  public FileCollection getGosuClasspath() {
     return _gosuClasspath;
   }
 
   @Override
-  public void setGosuClasspath(Closure<FileCollection> _gosuClasspathClosure) {
-    _gosuClasspath = _gosuClasspathClosure;
+  public void setGosuClasspath(FileCollection gosuClasspath) {
+    _gosuClasspath = gosuClasspath;
   }
 
   public GosuCompileOptions getGosuCompileOptions() {

--- a/src/main/java/org/gosulang/gradle/tasks/compile/GosuCompile.java
+++ b/src/main/java/org/gosulang/gradle/tasks/compile/GosuCompile.java
@@ -2,53 +2,44 @@ package org.gosulang.gradle.tasks.compile;
 
 import groovy.lang.Closure;
 import org.gosulang.gradle.tasks.InfersGosuRuntime;
-import org.gradle.api.GradleException;
 import org.gradle.api.Project;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
-import org.gradle.api.file.SourceDirectorySet;
-import org.gradle.api.internal.file.FileTreeInternal;
-import org.gradle.api.internal.tasks.compile.CompilationSourceDirs;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.*;
 import org.gradle.api.tasks.compile.AbstractCompile;
 import org.gradle.api.tasks.compile.CompileOptions;
-import org.gradle.util.VersionNumber;
+import org.gradle.process.ExecOperations;
 
 import javax.inject.Inject;
 import java.io.File;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import java.util.concurrent.Callable;
 
 import static org.gradle.api.tasks.PathSensitivity.NAME_ONLY;
 
 @CacheableTask
-public class GosuCompile extends AbstractCompile implements InfersGosuRuntime {
+public abstract class GosuCompile extends AbstractCompile implements InfersGosuRuntime {
 
   private GosuCompiler<GosuCompileSpec> _compiler;
-  private Closure<FileCollection> _gosuClasspath;
+  private ConfigurableFileCollection gosuClasspath;
+  private ConfigurableFileCollection _sourceRoots;
+  private CompileOptions _compileOptions;
+  private final GosuCompileOptions _gosuCompileOptions = new GosuCompileOptions();
   private Closure<FileCollection> _orderClasspath;
 
-  private final CompileOptions _compileOptions;
-  private final GosuCompileOptions _gosuCompileOptions = new GosuCompileOptions();
-  private final FileCollection stableSources = getProject().files(new Callable<FileTree>() {
-    @Override
-    public FileTree call() {
-      return getSource();
-    }
-  });
+  @Inject
+  protected abstract ObjectFactory getObjectFactory();
 
   @Inject
-  public GosuCompile() {
-      _compileOptions = getServices().get(ObjectFactory.class).newInstance(CompileOptions.class);
-  }
+  protected abstract ExecOperations getExecOperations();
+
+  @Inject
+  protected abstract ProjectLayout getLayout();
 
   @TaskAction
   protected void compile() {
@@ -70,7 +61,7 @@ public class GosuCompile extends AbstractCompile implements InfersGosuRuntime {
   @PathSensitive(NAME_ONLY)
   @InputFiles
   public FileCollection getStableSources() {
-    return stableSources;
+    return getSource();
   }
 
   /**
@@ -83,6 +74,9 @@ public class GosuCompile extends AbstractCompile implements InfersGosuRuntime {
 
   @Nested
   public CompileOptions getOptions() {
+    if (_compileOptions == null) {
+      _compileOptions = getObjectFactory().newInstance(CompileOptions.class);
+    }
     return _compileOptions;
   }
 
@@ -100,13 +94,22 @@ public class GosuCompile extends AbstractCompile implements InfersGosuRuntime {
   @Override
   @Classpath
   @InputFiles
-  public Closure<FileCollection> getGosuClasspath() {
-    return _gosuClasspath;
+  public ConfigurableFileCollection getGosuClasspath() {
+    // Lazily initialized so that no explicit @Inject constructor is needed; the abstract
+    // getObjectFactory() service getter is available as soon as the task is decorated.
+    // Field named 'gosuClasspath' (not '_gosuClasspath') so Gradle's CC BeanPropertyWriter can
+    // locate the convention mapping by field name and serialize the inferred classpath at CC store
+    // time. An underscore-prefixed name would mismatch the convention key and the injected
+    // __gosuClasspath__ explicit-flag field, breaking CC (gosuClasspath always empty on reuse).
+    if (gosuClasspath == null) {
+      gosuClasspath = getObjectFactory().fileCollection();
+    }
+    return gosuClasspath;
   }
 
   @Override
-  public void setGosuClasspath(Closure<FileCollection> gosuClasspathClosure) {
-    _gosuClasspath = gosuClasspathClosure;
+  public void setGosuClasspath(FileCollection gosuClasspath) {
+    getGosuClasspath().setFrom(gosuClasspath);
   }
 
   /**
@@ -130,63 +133,40 @@ public class GosuCompile extends AbstractCompile implements InfersGosuRuntime {
     _orderClasspath = orderClasspath;
   }
 
-/*  @Internal
-  public FileCollection getSourceRoots() {
-    Set<File> returnValues = new HashSet<>();
-    //noinspection Convert2streamapi
-   //  for(Object obj : getSourceReflectively()) {
-    for(Object obj : getSource()) {
-      if(obj instanceof SourceDirectorySet) {
-        returnValues.addAll(((SourceDirectorySet) obj).getSrcDirs());
-      }
+  /**
+   * Returns the Gosu source roots (directories). Wired at configuration time by {@code GosuBasePlugin}
+   * using the {@link org.gradle.api.file.SourceDirectorySet#getSourceDirectories()} public API.
+   */
+  @Internal
+  public ConfigurableFileCollection getSourceRoots() {
+    if (_sourceRoots == null) {
+      _sourceRoots = getObjectFactory().fileCollection();
     }
-    return getProject().files(returnValues);
-  }*/
-
-
-@Internal
-public FileCollection getSourceRoots() {
-  FileTreeInternal stableSourcesAsFileTree = (FileTreeInternal) getStableSources().getAsFileTree();
-  List<File> sourceRoots = CompilationSourceDirs.inferSourceRoots(stableSourcesAsFileTree);
-  return getProject().getLayout().files(sourceRoots);
-}
-
-
-
-  //!! todo: find a better way to iterate the FileTree
-  private Iterable getSourceReflectively() {
-    try {
-     // Field field = SourceTask.class.getDeclaredField("source");
-      Field field = SourceTask.class.getDeclaredField("sourceFiles");
-      field.setAccessible(true);
-      return (Iterable)field.get(this);
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
+    return _sourceRoots;
   }
 
   private DefaultGosuCompileSpec createSpec() {
     DefaultGosuCompileSpec spec = new DefaultGosuCompileSpec();
-    Project project = getProject();
     spec.setSource(getSource());
     spec.setSourceRoots(getSourceRoots());
     spec.setDestinationDir(getDestinationDirectory().get().getAsFile());
     spec.setTempDir(getTemporaryDir());
     spec.setGosuClasspath(getGosuClasspath());
-    spec.setCompileOptions(_compileOptions);
+    spec.setCompileOptions(getOptions());
     spec.setGosuCompileOptions(_gosuCompileOptions);
 
     if (_orderClasspath == null) {
       spec.setClasspath(asList(getClasspath()));
     } else {
+      // TODO: orderClasspath closure receives a Project reference — eliminate when orderClasspath is modernized
+      Project project = getProject();
       spec.setClasspath(asList(_orderClasspath.call(project, project.getConfigurations().getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME))));
-      //spec.setClasspath(asList(_orderClasspath.call(project, project.getConfigurations().getByName(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME))));
     }
 
-    Logger logger = project.getLogger();
+    Logger logger = getLogger();
 
     if(logger.isInfoEnabled()) {
-      logger.info("Gosu Compiler source roots for {} are:", project.getName());
+      logger.info("Gosu Compiler source roots for {} are:", getPath());
       if(spec.getSourceRoots().isEmpty()) {
         logger.info("<empty>");
       } else {
@@ -195,7 +175,7 @@ public FileCollection getSourceRoots() {
         }
       }
 
-      logger.info("Gosu Compiler Spec classpath for {} is:", project.getName());
+      logger.info("Gosu Compiler Spec classpath for {} is:", getPath());
       if(!spec.getClasspath().iterator().hasNext()) {
         logger.info("<empty>");
       } else {
@@ -204,13 +184,13 @@ public FileCollection getSourceRoots() {
         }
       }
 
-      logger.info("Gosu Compile Spec gosuClasspath for {} is:", project.getName());
-      FileCollection gosuClasspath = spec.getGosuClasspath().call();
+      logger.info("Gosu Compile Spec gosuClasspath for {} is:", getPath());
+      FileCollection gosuClasspath = spec.getGosuClasspath();
       if(gosuClasspath.isEmpty()) {
         logger.info("<empty>");
       } else {
-      for(File file : gosuClasspath) {
-        logger.info(file.getAbsolutePath());
+        for(File file : gosuClasspath) {
+          logger.info(file.getAbsolutePath());
         }
       }
     }
@@ -220,7 +200,8 @@ public FileCollection getSourceRoots() {
 
   private GosuCompiler<GosuCompileSpec> getCompiler(GosuCompileSpec spec) {
     if(_compiler == null) {
-      GosuCompilerFactory gosuCompilerFactory = new GosuCompilerFactory(getProject(), this.getPath());
+      File projectDir = getLayout().getProjectDirectory().getAsFile();
+      GosuCompilerFactory gosuCompilerFactory = new GosuCompilerFactory(getExecOperations(), getObjectFactory(), projectDir, getPath());
       _compiler = gosuCompilerFactory.newCompiler(spec);
     }
     return _compiler;

--- a/src/main/java/org/gosulang/gradle/tasks/compile/GosuCompileSpec.java
+++ b/src/main/java/org/gosulang/gradle/tasks/compile/GosuCompileSpec.java
@@ -1,11 +1,14 @@
 package org.gosulang.gradle.tasks.compile;
 
-import org.gosulang.gradle.tasks.InfersGosuRuntime;
 import org.gradle.api.file.FileCollection;
 
 import java.io.File;
 
-interface GosuCompileSpec extends InfersGosuRuntime {
+interface GosuCompileSpec {
+
+  FileCollection getGosuClasspath();
+
+  void setGosuClasspath(FileCollection gosuClasspath);
 
   MinimalGosuCompileOptions getCompileOptions();
 

--- a/src/main/java/org/gosulang/gradle/tasks/compile/GosuCompilerFactory.java
+++ b/src/main/java/org/gosulang/gradle/tasks/compile/GosuCompilerFactory.java
@@ -1,15 +1,22 @@
 package org.gosulang.gradle.tasks.compile;
 
-import org.gradle.api.Project;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.process.ExecOperations;
+
+import java.io.File;
 
 public class GosuCompilerFactory implements IGosuCompilerFactory<GosuCompileSpec> {
 
-  private final Project _project;
+  private final ExecOperations _execOperations;
+  private final ObjectFactory _objectFactory;
+  private final File _projectDir;
   private final String _taskPath;
 
-  public GosuCompilerFactory(Project project, String forTask) {
-    _project = project;
-    _taskPath = forTask;
+  public GosuCompilerFactory(ExecOperations execOperations, ObjectFactory objectFactory, File projectDir, String taskPath) {
+    _execOperations = execOperations;
+    _objectFactory = objectFactory;
+    _projectDir = projectDir;
+    _taskPath = taskPath;
   }
 
   @Override
@@ -17,7 +24,7 @@ public class GosuCompilerFactory implements IGosuCompilerFactory<GosuCompileSpec
     GosuCompileOptions gosuOptions = spec.getGosuCompileOptions();
     GosuCompiler<GosuCompileSpec> gosuCompiler;
     if(gosuOptions.isFork()) {
-      gosuCompiler = new CommandLineGosuCompiler(_project, spec, _taskPath);
+      gosuCompiler = new CommandLineGosuCompiler(_execOperations, _objectFactory, spec, _taskPath, _projectDir);
     } else {
       gosuCompiler = new InProcessGosuCompiler();
     }

--- a/src/main/java/org/gosulang/gradle/tasks/gosudoc/CommandLineGosuDoc.java
+++ b/src/main/java/org/gosulang/gradle/tasks/gosudoc/CommandLineGosuDoc.java
@@ -4,11 +4,14 @@ import org.apache.tools.ant.taskdefs.condition.Os;
 import org.gosulang.gradle.tasks.Util;
 import org.gradle.api.GradleException;
 import org.gradle.api.JavaVersion;
-import org.gradle.api.Project;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.FileSystemOperations;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.compile.BaseForkOptions;
+import org.gradle.process.ExecOperations;
 import org.gradle.process.ExecResult;
 import org.gradle.process.JavaExecSpec;
 import org.gradle.tooling.BuildException;
@@ -26,47 +29,55 @@ import java.util.regex.Pattern;
 
 public class CommandLineGosuDoc {
   private static final Logger LOGGER = Logging.getLogger(CommandLineGosuDoc.class);
-  
+
   private final FileCollection _source;
   private final File _targetDir;
   private final FileCollection _projectClasspath;
   private final FileCollection _gosuClasspath;
   private final GosuDocOptions _options;
-  private final Project _project;
+  private final ExecOperations _execOperations;
+  private final FileSystemOperations _fileSystemOperations;
+  private final ObjectFactory _objectFactory;
+  private final ProjectLayout _layout;
+  private final String _taskPath;
 
-
-  public CommandLineGosuDoc(FileCollection source, File targetDir, FileCollection gosuClasspath, FileCollection projectClasspath, GosuDocOptions options, Project project) {
+  public CommandLineGosuDoc(FileCollection source, File targetDir, FileCollection gosuClasspath, FileCollection projectClasspath, GosuDocOptions options,
+                            ExecOperations execOperations, FileSystemOperations fileSystemOperations, ObjectFactory objectFactory, ProjectLayout layout, String taskPath) {
     _source = source;
     _targetDir = targetDir;
     _gosuClasspath = gosuClasspath;
     _projectClasspath = projectClasspath;
     _options = options;
-    _project = project;
+    _execOperations = execOperations;
+    _fileSystemOperations = fileSystemOperations;
+    _objectFactory = objectFactory;
+    _layout = layout;
+    _taskPath = taskPath;
   }
-  
+
   public void execute() {
     String startupMsg = "Initializing gosudoc generator";
-    if(_project.getName().isEmpty()) {
-      startupMsg += " for " + _project.getName();
+    if(_taskPath.isEmpty()) {
+      startupMsg += " for " + _taskPath;
     }
     LOGGER.info(startupMsg);
-    
+
     //'source' is a FileCollection with explicit paths.
     // We don't want that, so instead we create a temp directory with the contents of 'source'
-    // Copying 'source' to the temp dir should honor its include/exclude patterns
-    // Finally, the tmpdir will be the sole inputdir passed to the gosudoc task
-    final File tmpDir = new File(_project.getBuildDir(), "tmp/gosudoc");
-    _project.delete(tmpDir);
-    _project.copy(copySpec -> copySpec.from(_source).into(tmpDir));
+    // Copying 'source' to the temp dir should honor its include/exclude patterns.
+    // Finally, the tmpdir will be the sole inputdir passed to the gosudoc task.
+    final File tmpDir = _layout.getBuildDirectory().dir("tmp/gosudoc").get().getAsFile();
+    _fileSystemOperations.delete(spec -> spec.delete(tmpDir));
+    _fileSystemOperations.copy(spec -> spec.from(_source).into(tmpDir));
 
     List<String> gosudocArgs = new ArrayList<>();
 
     gosudocArgs.add("-inputDirs");
     gosudocArgs.add(tmpDir.getAbsolutePath());
-    
+
     gosudocArgs.add("-output");
     gosudocArgs.add(_targetDir.getAbsolutePath());
-    
+
     if(_options.isVerbose()) {
       gosudocArgs.add("-verbose");
     }
@@ -74,9 +85,9 @@ public class CommandLineGosuDoc {
     ByteArrayOutputStream stdout = new ByteArrayOutputStream();
     ByteArrayOutputStream stderr = new ByteArrayOutputStream();
 
-    FileCollection jointClasspath = _project.files(_gosuClasspath).plus(_projectClasspath);
+    FileCollection jointClasspath = _gosuClasspath.plus(_projectClasspath);
     if (!JavaVersion.current().isJava11Compatible()) { //if it is not java 11
-      jointClasspath = jointClasspath.plus(_project.files(Util.findToolsJar()));
+      jointClasspath = jointClasspath.plus(_objectFactory.fileCollection().from(Util.findToolsJar()));
     }
 
     //FileCollection jointClasspath = _project.files(_gosuClasspath).plus(_projectClasspath);
@@ -87,15 +98,15 @@ public class CommandLineGosuDoc {
     } catch (IOException e) {
       throw new BuildException("Error creating classpath JAR for gosudoc generation", e);
     }
-    
-    LOGGER.info("Created classpathJar at " + classpathJar.getAbsolutePath());
-    
-    ExecResult result = _project.javaexec(javaExecSpec -> {
 
-      javaExecSpec.setWorkingDir((Object) _project.getProjectDir()); // Gradle 4.0 overloads ProcessForkOptions#setWorkingDir; must upcast to Object for backwards compatibility
+    LOGGER.info("Created classpathJar at " + classpathJar.getAbsolutePath());
+
+    ExecResult result = _execOperations.javaexec(javaExecSpec -> {
+
+      javaExecSpec.setWorkingDir((Object) _layout.getProjectDirectory().getAsFile()); // Gradle 4.0 overloads ProcessForkOptions#setWorkingDir; must upcast to Object for backwards compatibility
       setJvmArgs(javaExecSpec, _options.getForkOptions());
       javaExecSpec.getMainClass().set("gw.gosudoc.cli.Gosudoc");
-      javaExecSpec.setClasspath(_project.files(classpathJar))
+      javaExecSpec.setClasspath(_objectFactory.fileCollection().from(classpathJar))
           .setArgs((Iterable<?>) gosudocArgs); // Gradle 4.0 overloads JavaExecSpec#setArgs; must upcast to Iterable<?> for backwards compatibility
       javaExecSpec.setStandardOutput(stdout);
       javaExecSpec.setErrorOutput(stderr);
@@ -123,27 +134,27 @@ public class CommandLineGosuDoc {
     } else {
       tempFile = File.createTempFile(CommandLineGosuDoc.class.getName(), "classpath.jar");
       tempFile.deleteOnExit();
-    }    
-    
+    }
+
     LOGGER.info("Creating classpath JAR at " + tempFile.getAbsolutePath());
-    
+
     Manifest man = new Manifest();
     man.getMainAttributes().putValue(Attributes.Name.MANIFEST_VERSION.toString(), "1.0");
     man.getMainAttributes().putValue(Attributes.Name.CLASS_PATH.toString(), convertFileCollectionToURIs(classpath));
 
     //noinspection EmptyTryBlock
-    try(FileOutputStream fos = new FileOutputStream(tempFile); 
+    try(FileOutputStream fos = new FileOutputStream(tempFile);
         JarOutputStream jarOut = new JarOutputStream(fos, man)) {
         //This is a bit silly.
-        //The try-with-resources construct with two autoclosable resources saves us 
+        //The try-with-resources construct with two autoclosable resources saves us
         //from having to deal with a boilerplate finally block to close the streams.
         //Further, the JarOutputStream constructor with Manifest attribute does all the work we need,
         //which is why the try block is intentionally empty.
     }
-    
+
     return tempFile;
   }
-  
+
   private String convertFileCollectionToURIs(FileCollection files) {
     List<String> entries = new ArrayList<>();
 
@@ -152,7 +163,7 @@ public class CommandLineGosuDoc {
       LOGGER.info("Encoding " + entry.getAbsolutePath());
         entries.add(entry.toURI().toString());
     }
-    
+
     return String.join(" ", entries);
   }
 
@@ -177,7 +188,7 @@ public class CommandLineGosuDoc {
     if(Os.isFamily(Os.FAMILY_MAC)) {
       args.add("-Xdock:name=gosudoc");
     }
-    
+
     spec.setJvmArgs((Iterable<?>) args); // Gradle 4.0 overloads JavaForkOptions#setJvmArgs; must upcast to Iterable<?> for backwards compatibility
   }
 

--- a/src/main/java/org/gosulang/gradle/tasks/gosudoc/GosuDoc.java
+++ b/src/main/java/org/gosulang/gradle/tasks/gosudoc/GosuDoc.java
@@ -1,10 +1,13 @@
 package org.gosulang.gradle.tasks.gosudoc;
 
-import groovy.lang.Closure;
 import org.gosulang.gradle.tasks.InfersGosuRuntime;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.file.FileTree;
-import org.gradle.api.logging.LogLevel;
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
@@ -16,21 +19,31 @@ import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SourceTask;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.process.ExecOperations;
 
+import javax.inject.Inject;
 import java.io.File;
 
 @CacheableTask
-public class GosuDoc extends SourceTask implements InfersGosuRuntime {
+public abstract class GosuDoc extends SourceTask implements InfersGosuRuntime {
 
   private FileCollection _classpath;
-  private Closure<FileCollection> _gosuClasspath;
-  private File _destinationDir;
+  private ConfigurableFileCollection gosuClasspath;
+  private DirectoryProperty _destinationDir;
   private GosuDocOptions _gosuDocOptions = new GosuDocOptions();
   private String _title;
 
-  public GosuDoc() {
-    getLogging().captureStandardOutput(LogLevel.INFO);
-  }
+  @Inject
+  protected abstract ExecOperations getExecOperations();
+
+  @Inject
+  protected abstract FileSystemOperations getFileSystemOperations();
+
+  @Inject
+  protected abstract ObjectFactory getObjectFactory();
+
+  @Inject
+  protected abstract ProjectLayout getLayout();
 
   /**
    * {@inheritDoc}
@@ -40,18 +53,26 @@ public class GosuDoc extends SourceTask implements InfersGosuRuntime {
   public FileTree getSource() {
     return super.getSource();
   }
-  
+
   /**
-   * Returns the target directory to generate the API documentation.
    * @return the target directory to generate the API documentation.
    */
   @OutputDirectory
-  public File getDestinationDir() {
+  public DirectoryProperty getDestinationDir() {
+    if (_destinationDir == null) {
+      _destinationDir = getObjectFactory().directoryProperty();
+    }
     return _destinationDir;
   }
 
-  public void setDestinationDir( File destinationDir ) {
-    _destinationDir = destinationDir;
+  /**
+   *
+   * @deprecated Use {@link #getDestinationDir()} methods
+   * @see DirectoryProperty
+   */
+  @Deprecated
+  public void setDestinationDir(File destinationDir) {
+    getDestinationDir().set(destinationDir);
   }
 
   /**
@@ -76,13 +97,17 @@ public class GosuDoc extends SourceTask implements InfersGosuRuntime {
   @Override
   @Classpath
   @InputFiles
-  public Closure<FileCollection> getGosuClasspath() {
-    return _gosuClasspath;
+  public ConfigurableFileCollection getGosuClasspath() {
+    // Field named 'gosuClasspath' (not '_gosuClasspath') — see GosuCompile for the CC rationale.
+    if (gosuClasspath == null) {
+      gosuClasspath = getObjectFactory().fileCollection();
+    }
+    return gosuClasspath;
   }
 
   @Override
-  public void setGosuClasspath( Closure<FileCollection> gosuClasspathClosure ) {
-    _gosuClasspath = gosuClasspathClosure;
+  public void setGosuClasspath(FileCollection gosuClasspath) {
+    getGosuClasspath().setFrom(gosuClasspath);
   }
 
   /**
@@ -118,6 +143,7 @@ public class GosuDoc extends SourceTask implements InfersGosuRuntime {
     if (options.getTitle() != null && !options.getTitle().isEmpty()) {
       options.setTitle(getTitle());
     }
-    new CommandLineGosuDoc(getSource(), getDestinationDir(), getGosuClasspath().call(), getClasspath(), options, getProject()).execute();
+    new CommandLineGosuDoc(getSource(), getDestinationDir().get().getAsFile(), getGosuClasspath(), getClasspath(), options,
+        getExecOperations(), getFileSystemOperations(), getObjectFactory(), getLayout(), getPath()).execute();
   }
 }

--- a/src/test/groovy/org/gosulang/gradle/functional/ConfigurationCacheCompileTest.groovy
+++ b/src/test/groovy/org/gosulang/gradle/functional/ConfigurationCacheCompileTest.groovy
@@ -1,0 +1,94 @@
+package org.gosulang.gradle.functional
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import spock.lang.Unroll
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+/**
+ * Guards the configuration-cache compatibility of the {@code compileGosu} task (issue #68).
+ *
+ * <p>{@code GosuBasePlugin.configureCompileDefaults()} wires {@code gosuClasspath} via convention
+ * mapping. On a CC-store build Gradle's {@code BeanPropertyWriter} evaluates the convention value
+ * (calling {@code GosuRuntime.inferGosuClasspath()}) and serialises the resulting file collection;
+ * on CC reuse the stored file list is restored directly, bypassing convention mapping entirely.</p>
+ *
+ * <p>For this to work the backing field in {@code GosuCompile} must be named {@code gosuClasspath}
+ * (no underscore prefix). {@code BeanPropertyWriter} looks up convention mappings by the field
+ * name; an underscore-prefixed name produces a key mismatch, so the convention is never found,
+ * {@code null} is stored, and {@code gosuClasspath} is empty on every CC-reuse run.</p>
+ *
+ * <p>PR #93 regressed this by replacing convention mapping with
+ * {@code ConfigurableFileCollection#from(Callable)} directly on the task property. CC then
+ * attempted to serialise the lambda at store time; when that failed the property was left
+ * unconfigured, causing a {@code WorkValidationException} ("property 'gosuClasspath' doesn't
+ * have a configured value") before the task action ran.</p>
+ *
+ * <p>We run {@code compileGosu} (not {@code --dry-run}) because {@code --dry-run} skips task
+ * execution and therefore never triggers task-property validation.</p>
+ *
+ * <p>We use {@code --configuration-cache-problems=warn} rather than
+ * {@code STABLE_CONFIGURATION_CACHE}: convention mapping produces a {@code RUNTIME_DEFAULT_VALUE}
+ * advisory that strict mode would promote to a build error.</p>
+ *
+ * <p><b>Regression coverage note:</b> the second run (CC reuse, identical inputs) is insufficient
+ * on its own — the task is UP-TO-DATE so {@code gosuClasspath} being empty would go undetected.
+ * The third run adds a new source file so the task re-executes under CC reuse; if
+ * {@code gosuClasspath} was serialised empty the compiler cannot find {@code gosu-core-api}
+ * and the build fails.</p>
+ */
+@Unroll
+class ConfigurationCacheCompileTest extends AbstractGosuPluginSpecification {
+
+    File srcMainGosu
+
+    @Override
+    def setup() {
+        srcMainGosu = testProjectDir.newFolder('src', 'main', 'gosu')
+    }
+
+    def 'compileGosu is configuration-cache compatible — gosuClasspath is wired [Gradle #gradleVersion]'() {
+        given:
+        buildScript << getBasicBuildScriptForTesting()
+
+        and: 'a minimal Gosu source file so compileGosu has work to do'
+        File pogo = new File(srcMainGosu, asPath('example', 'gradle', 'SimplePogo.gs'))
+        pogo.getParentFile().mkdirs()
+        pogo << 'package example.gradle\n\nclass SimplePogo {}'
+
+        when: 'the configuration cache entry is stored'
+        GradleRunner runner = GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withPluginClasspath()
+                .withArguments('compileGosu', '--configuration-cache', '--configuration-cache-problems=warn')
+                .withGradleVersion(gradleVersion)
+        BuildResult storeResult = runner.build()
+
+        then: 'compileGosu succeeds — gosuClasspath is wired via convention mapping so no WorkValidationException is thrown'
+        storeResult.task(':compileGosu').outcome == SUCCESS
+        storeResult.output.contains('Configuration cache entry stored.')
+        !storeResult.output.contains("property 'gosuClasspath' doesn't have a configured value")
+
+        when: 'the build runs again with identical inputs'
+        BuildResult reuseResult = runner.build()
+
+        then: 'the configuration cache entry is reused'
+        reuseResult.output.contains('Reusing configuration cache.')
+        reuseResult.output.contains('Configuration cache entry reused.')
+
+        when: 'a new source file is added, forcing compileGosu to re-execute under CC reuse'
+        File pogo2 = new File(srcMainGosu, asPath('example', 'gradle', 'AnotherPogo.gs'))
+        pogo2.getParentFile().mkdirs()
+        pogo2 << 'package example.gradle\n\nclass AnotherPogo {}'
+        BuildResult rerunResult = runner.build()
+
+        then: 'CC is still reused and the task executes successfully — gosuClasspath was correctly stored in the CC entry'
+        rerunResult.output.contains('Reusing configuration cache.')
+        rerunResult.task(':compileGosu').outcome == SUCCESS
+        !rerunResult.output.contains("property 'gosuClasspath' doesn't have a configured value")
+
+        where:
+        gradleVersion << gradleVersionsToTest
+    }
+}

--- a/src/test/groovy/org/gosulang/gradle/functional/gosudoc/ConfigurationCacheGosudocTest.groovy
+++ b/src/test/groovy/org/gosulang/gradle/functional/gosudoc/ConfigurationCacheGosudocTest.groovy
@@ -1,0 +1,79 @@
+package org.gosulang.gradle.functional.gosudoc
+
+import org.gosulang.gradle.functional.AbstractGosuPluginSpecification
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import spock.lang.Unroll
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+/**
+ * Guards the configuration-cache compatibility of the {@code gosudoc} task (issue #68).
+ *
+ * <p>See {@code ConfigurationCacheCompileTest} for a detailed explanation of the CC model,
+ * the convention-mapping approach, and the field-naming requirement.</p>
+ *
+ * <p>We use {@code --configuration-cache-problems=warn} rather than
+ * {@code STABLE_CONFIGURATION_CACHE}: convention mapping (the default wiring) produces a
+ * {@code RUNTIME_DEFAULT_VALUE} advisory that strict mode would promote to a build error.</p>
+ *
+ * <p><b>Regression coverage note:</b> the second run (CC reuse, identical inputs) is insufficient
+ * on its own — the task is UP-TO-DATE so {@code gosuClasspath} being empty would go undetected.
+ * The third run adds a new source file so the task re-executes under CC reuse; if
+ * {@code gosuClasspath} was serialised empty the gosudoc tool cannot find {@code gosu-core-api}
+ * and the build fails.</p>
+ */
+@Unroll
+class ConfigurationCacheGosudocTest extends AbstractGosuPluginSpecification {
+
+    File srcMainGosu
+
+    @Override
+    def setup() {
+        srcMainGosu = testProjectDir.newFolder('src', 'main', 'gosu')
+    }
+
+    def 'gosudoc is configuration-cache compatible [Gradle #gradleVersion]'() {
+        given:
+        buildScript << getBasicBuildScriptForTesting()
+
+        and: 'a minimal Gosu source file so gosudoc has work to do'
+        File pogo = new File(srcMainGosu, asPath('example', 'gradle', 'SimplePogo.gs'))
+        pogo.getParentFile().mkdirs()
+        pogo << 'package example.gradle\n\nclass SimplePogo {}'
+
+        when: 'the configuration cache entry is stored'
+        GradleRunner runner = GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withPluginClasspath()
+                .withArguments('gosudoc', '--configuration-cache', '--configuration-cache-problems=warn')
+                .withGradleVersion(gradleVersion)
+        BuildResult storeResult = runner.build()
+
+        then:
+        storeResult.task(':gosudoc').outcome == SUCCESS
+        storeResult.output.contains('Configuration cache entry stored.')
+        !storeResult.output.contains("property 'gosuClasspath' doesn't have a configured value")
+
+        when: 'the build runs again with identical inputs'
+        BuildResult reuseResult = runner.build()
+
+        then: 'the configuration cache entry is reused'
+        reuseResult.output.contains('Reusing configuration cache.')
+        reuseResult.output.contains('Configuration cache entry reused.')
+
+        when: 'a new source file is added, forcing gosudoc to re-execute under CC reuse'
+        File pogo2 = new File(srcMainGosu, asPath('example', 'gradle', 'AnotherPogo.gs'))
+        pogo2.getParentFile().mkdirs()
+        pogo2 << 'package example.gradle\n\nclass AnotherPogo {}'
+        BuildResult rerunResult = runner.build()
+
+        then: 'CC is still reused and the task executes successfully — gosuClasspath was correctly stored in the CC entry'
+        rerunResult.output.contains('Reusing configuration cache.')
+        rerunResult.task(':gosudoc').outcome == SUCCESS
+        !rerunResult.output.contains("property 'gosuClasspath' doesn't have a configured value")
+
+        where:
+        gradleVersion << gradleVersionsToTest
+    }
+}

--- a/src/test/groovy/org/gosulang/gradle/unit/GosuRuntimeTest.groovy
+++ b/src/test/groovy/org/gosulang/gradle/unit/GosuRuntimeTest.groovy
@@ -16,8 +16,8 @@ class GosuRuntimeTest extends Specification {
 
     def 'inference fails if no repository declared'() {
         when:
-        def gosuClasspath = project.gosuRuntime.inferGosuClasspath([new File('other.jar'), new File('gosu-core-api-1.8.jar')])
-        gosuClasspath.call().files
+        def gosuClasspath = project.gosuRuntime.inferGosuClasspath(project.files([new File('other.jar'), new File('gosu-core-api-1.8.jar')]))
+        gosuClasspath.files
 
         then:
         GradleException e = thrown()


### PR DESCRIPTION
#87 did the minimum work for a `--dry-run` configuration cache opt-in.

But at task execution time, there are many other illegal usages of the `Project` APIs.

This replaces them, as well as removing Gradle `internal` package usages.

This is also technically a breaking API change, though I doubt the effects are significant.  Nevertheless I'm considering bumping version to 8.2.x or 9.x for release.

The changes most affecting task configurers would be widening of some `FileCollection` types to `ConfigurableFileCollection`.

Full list of public changes here:

- InfersGosuRuntime.getGosuClasspath() — return type widened from FileCollection to ConfigurableFileCollection; any external implementor of the interface breaks
- GosuCompileSpec — no longer extends InfersGosuRuntime; any code depending on that relationship breaks
- GosuCompile — now abstract; cannot be directly instantiated
- GosuCompile.getGosuClasspath() — return type widened to ConfigurableFileCollection
- GosuCompile.getSourceRoots() — return type widened to ConfigurableFileCollection
- GosuCompilerFactory constructor — Project replaced with ExecOperations, ObjectFactory, File; binary-incompatible
- CommandLineGosuCompiler constructor — same replacement; binary-incompatible
- GosuDoc — now abstract; cannot be directly instantiated
- GosuDoc.getDestinationDir() — return type changed from File to DirectoryProperty; binary-incompatible
- GosuDoc.getGosuClasspath() — return type widened to ConfigurableFileCollection
- CommandLineGosuDoc constructor — Project replaced with five service parameters; binary-incompatible
