### PR TITLE
Configuration Cache regression : fix source() override to propagate directory args to sourceRoots (#68)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group=org.gosu-lang.gosu
 name=gradle-gosu-plugin
-version=8.1.5
+version=8.1.6-SNAPSHOT
 
 gradleVersion=8.6
 org.gradle.caching=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group=org.gosu-lang.gosu
 name=gradle-gosu-plugin
-version=8.1.5-SNAPSHOT
+version=8.1.5
 
 gradleVersion=8.6
 org.gradle.caching=false

--- a/src/main/java/org/gosulang/gradle/tasks/compile/GosuCompile.java
+++ b/src/main/java/org/gosulang/gradle/tasks/compile/GosuCompile.java
@@ -7,6 +7,7 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.JavaPlugin;
@@ -55,6 +56,25 @@ public abstract class GosuCompile extends AbstractCompile implements InfersGosuR
   @PathSensitive(NAME_ONLY)
   public FileTree getSource() {
     return super.getSource();
+  }
+
+  /**
+   * Overrides {@link SourceTask#source} to also register non-{@link SourceDirectorySet},
+   * non-{@link FileTree} arguments in {@link #getSourceRoots()} so that directories added by
+   * external plugins (e.g. via a {@code Provider<Directory>} or {@code Provider<File>}) are
+   * treated as Gosu type-system source roots.  {@code SourceDirectorySet} is excluded because
+   * {@code GosuBasePlugin} already wires its {@code getSourceDirectories()} into
+   * {@code sourceRoots}.  {@code FileTree} is excluded because resolving one yields individual
+   * files rather than root directories.
+   */
+  @Override
+  public SourceTask source(Object... sources) {
+    for (Object s : sources) {
+      if (!(s instanceof SourceDirectorySet) && !(s instanceof FileTree)) {
+        getSourceRoots().from(s);
+      }
+    }
+    return super.source(sources);
   }
 
   @SkipWhenEmpty

--- a/src/test/groovy/org/gosulang/gradle/functional/ExternalSourceDirectoryCompileTest.groovy
+++ b/src/test/groovy/org/gosulang/gradle/functional/ExternalSourceDirectoryCompileTest.groovy
@@ -1,0 +1,119 @@
+package org.gosulang.gradle.functional
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import spock.lang.Unroll
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+/**
+ * Regression test for the source-root inference regression introduced in 8.1.4.
+ *
+ * <p>When an external plugin adds a source directory to {@code compileGosu} via
+ * {@link org.gradle.api.tasks.SourceTask#source}, that directory must also appear
+ * in the task's {@code sourceRoots} collection so the Gosu type system can resolve
+ * type names from file paths.  Prior to 8.1.4 this was handled implicitly by the
+ * internal {@code CompilationSourceDirs.inferSourceRoots}; 8.1.4 switched to an
+ * explicit config-time wiring that only covered directories declared through the
+ * Gosu {@link org.gradle.api.file.SourceDirectorySet}, missing any directory added
+ * after configuration via {@code source()}.
+ *
+ * <p>The canonical caller pattern is a plugin that adds a pre-populated directory
+ * (e.g. a {@code Provider<Directory>} from a download task) via:
+ * <pre>
+ *   tasks.named("compileGosu", SourceTask.class,
+ *       t -&gt; t.source(downloadTask.map(t -&gt; t.getDestinationDir())));
+ * </pre>
+ * Without the fix, gosuc fails with
+ * {@code "Cannot find type in the Gosu Type System"} at {@code [0,0]} for every
+ * Gosu file in the externally-added directory, because the Gosu type system cannot
+ * derive the fully-qualified type name without knowing the source root.
+ */
+@Unroll
+class ExternalSourceDirectoryCompileTest extends AbstractGosuPluginSpecification {
+
+    File srcMainGosu
+
+    def setup() {
+        srcMainGosu = testProjectDir.newFolder('src', 'main', 'gosu')
+    }
+
+    def 'source directory added via SourceTask.source() is compiled successfully [Gradle #gradleVersion]'() {
+        given: 'a normal Gosu source file in the standard source set'
+        buildScript << getBasicBuildScriptForTesting() + """
+            // Simulate an external plugin adding a pre-populated directory via SourceTask.source()
+            // rather than through the Gosu source set (the plugin cannot cast to GosuCompile).
+            def externalDir = layout.projectDirectory.dir('src/external/gosu')
+            tasks.named('compileGosu', org.gradle.api.tasks.SourceTask) {
+                source externalDir
+            }
+        """
+        File pogo = new File(srcMainGosu, asPath('example', 'gradle', 'SimplePogo.gs'))
+        pogo.getParentFile().mkdirs()
+        pogo << 'package example.gradle\n\nclass SimplePogo {}'
+
+        and: 'a Gosu source file in the external directory — added via source(), not via the Gosu source set'
+        File externalSrc = testProjectDir.newFolder('src', 'external', 'gosu', 'example', 'gradle')
+        new File(externalSrc, 'ExternalPogo.gs') << 'package example.gradle\n\nclass ExternalPogo {}'
+
+        when:
+        BuildResult result = GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withPluginClasspath()
+                .withArguments('compileGosu')
+                .withGradleVersion(gradleVersion)
+                .build()
+
+        then: 'both source files compile — the externally-added directory is recognised as a source root'
+        result.task(':compileGosu').outcome == SUCCESS
+
+        where:
+        gradleVersion << gradleVersionsToTest
+    }
+
+    def 'external sourceRoots survive configuration-cache serialisation [Gradle #gradleVersion]'() {
+        given: 'a project with a standard and an externally-wired source directory'
+        buildScript << getBasicBuildScriptForTesting() + """
+            def externalDir = layout.projectDirectory.dir('src/external/gosu')
+            tasks.named('compileGosu', org.gradle.api.tasks.SourceTask) {
+                source externalDir
+            }
+        """
+        File pogo = new File(srcMainGosu, asPath('example', 'gradle', 'SimplePogo.gs'))
+        pogo.getParentFile().mkdirs()
+        pogo << 'package example.gradle\n\nclass SimplePogo {}'
+
+        File externalSrc = testProjectDir.newFolder('src', 'external', 'gosu', 'example', 'gradle')
+        new File(externalSrc, 'ExternalPogo.gs') << 'package example.gradle\n\nclass ExternalPogo {}'
+
+        when: 'the configuration cache entry is stored'
+        GradleRunner runner = GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withPluginClasspath()
+                .withArguments('compileGosu', '--configuration-cache', '--configuration-cache-problems=warn')
+                .withGradleVersion(gradleVersion)
+        BuildResult storeResult = runner.build()
+
+        then:
+        storeResult.task(':compileGosu').outcome == SUCCESS
+        storeResult.output.contains('Configuration cache entry stored.')
+
+        when: 'the build runs again with identical inputs'
+        BuildResult reuseResult = runner.build()
+
+        then: 'the CC entry is reused'
+        reuseResult.output.contains('Reusing configuration cache.')
+        reuseResult.output.contains('Configuration cache entry reused.')
+
+        when: 'a new file is added to the external directory, forcing compileGosu to re-execute under CC reuse'
+        new File(externalSrc, 'AnotherExternalPogo.gs') << 'package example.gradle\n\nclass AnotherExternalPogo {}'
+        BuildResult rerunResult = runner.build()
+
+        then: 'CC is still reused and the external sourceRoot was correctly preserved in the CC entry'
+        rerunResult.output.contains('Reusing configuration cache.')
+        rerunResult.task(':compileGosu').outcome == SUCCESS
+
+        where:
+        gradleVersion << gradleVersionsToTest
+    }
+}


### PR DESCRIPTION
External plugins that add a source directory to compileGosu via SourceTask.source() (e.g. passing a Provider<Directory> or Provider<File>) had their directories silently dropped from sourceRoots after the 8.1.4 CC refactor removed the implicit CompilationSourceDirs.inferSourceRoots inference.  gosuc then failed with "Cannot find type in the Gosu Type System" because it could not derive fully-qualified type names without knowing the source root.

Override source() in GosuCompile to also call getSourceRoots().from() for non-SourceDirectorySet, non-FileTree arguments.  SourceDirectorySet is excluded because GosuBasePlugin already wires getSourceDirectories() into sourceRoots.  FileTree is excluded because resolving one yields individual files rather than root directories.  GosuBasePlugin uses setSource() (not source()), so the override is not triggered for normal source-set wiring.

Includes regression test ExternalSourceDirectoryCompileTest covering both the basic compile case and CC serialization of external sourceRoots.