### PR TITLE
Gradle 9 preparation

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,11 +17,11 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
 
-      - name: Set up Java (Amazon Corretto 11)
+      - name: Set up Java (Amazon Corretto 21)
         uses: actions/setup-java@v4
         with:
           distribution: 'corretto'
-          java-version: '11'
+          java-version: '21'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
@@ -35,7 +35,7 @@ jobs:
         if: always()
         run: |
           echo "## 🧪 Test Results Summary" >> $GITHUB_STEP_SUMMARY
-          echo "**Java Version:** 11" >> $GITHUB_STEP_SUMMARY
+          echo "**Java Version:** 21" >> $GITHUB_STEP_SUMMARY
           # Count test files and results
           TOTAL_FILES=$(find build/test-results -name "TEST-*.xml" 2>/dev/null | wc -l)
           echo "**Test report files:** $TOTAL_FILES" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish-snapshots.yml
+++ b/.github/workflows/publish-snapshots.yml
@@ -16,11 +16,11 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
 
-      - name: Set up Java (Amazon Corretto 11)
+      - name: Set up Java (Amazon Corretto 21)
         uses: actions/setup-java@v4
         with:
           distribution: 'corretto'
-          java-version: '11'
+          java-version: '21'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,11 +24,11 @@ jobs:
             exit 1
           fi
 
-      - name: Set up Java (Amazon Corretto 11)
+      - name: Set up Java (Amazon Corretto 21)
         uses: actions/setup-java@v4
         with:
           distribution: 'corretto'
-          java-version: '11'
+          java-version: '21'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5

--- a/build.gradle
+++ b/build.gradle
@@ -124,8 +124,12 @@ if(System.getenv('CI') != null) {
         options.fork = false
     }
     test {
-        maxHeapSize = '1g'
-        systemProperty 'org.gradle.testkit.debug', 'true' // prevents the testkit from spawning daemons and running out of memory
+        maxHeapSize = '2g'
+        // `org.gradle.testkit.debug=true` forces all testkit tests to share the same in-process daemon
+        // Previously this was nice and kept memory usage low, but with JDK 16+ causes issues with --add-opens and the daemon and configuration cache tests
+        // See GradleRunner withDebug(true) with Config cache fails with Unable to make field SerializedLambda.capturedArgs accessible · Issue #22765 · gradle/gradle (https://github.com/gradle/gradle/issues/22765)
+        // and Config Cache support for serializing java.lang.invoke.SerializedLambda · Issue #24981 · gradle/gradle (https://github.com/gradle/gradle/issues/24981)
+        //systemProperty 'org.gradle.testkit.debug', 'true' // prevents the testkit from spawning daemons and running out of memory
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -53,8 +53,18 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of javaVersion
     }
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
     withSourcesJar()
     withJavadocJar()
+}
+
+tasks.withType(JavaCompile).configureEach {
+    // --release (not just source/targetCompatibility) so the compiler validates against the
+    // actual Java 8 API surface, rejecting JDK 9+-only APIs (e.g. List.of()) whose return
+    // types are internal JDK immutable-collection implementations that have a history of
+    // breaking Gradle's Configuration Cache serialization.
+    options.release = 8
 }
 
 gradlePlugin {

--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,7 @@ tasks.withType(JavaCompile).configureEach {
     // actual Java 8 API surface, rejecting JDK 9+-only APIs (e.g. List.of()) whose return
     // types are internal JDK immutable-collection implementations that have a history of
     // breaking Gradle's Configuration Cache serialization.
+    // See https://github.com/gradle/gradle/issues/26942
     options.release = 8
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ researchgateReleaseGradlePluginVersion=3.0.2
 reproducibleBuildsPluginVersion=1.0
 
 # For docker container
-javaVersion=11
+javaVersion=21
 
 # Test implementation dependencies
 assertjCoreVersion=3.24.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ org.gradle.parallel=false
 org.gradle.workers.max=1
 
 gosuVersion=1.18.7
-testedVersions=8.2,8.10.1,8.14.5
+testedVersions=8.2,8.10.1,8.14.5,9.6.1
 
 # Gradle plugins
 gradlePublishPluginVersion=1.3.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ org.gradle.jvmargs=-Xms1g -Xmx2g -Dfile.encoding=UTF-8
 org.gradle.parallel=false
 org.gradle.workers.max=1
 
-gosuVersion=1.17.8
+gosuVersion=1.18.7
 testedVersions=8.2,8.10.1,8.14.5
 
 # Gradle plugins

--- a/src/main/java/org/gosulang/gradle/GosuBasePlugin.java
+++ b/src/main/java/org/gosulang/gradle/GosuBasePlugin.java
@@ -1,7 +1,6 @@
 package org.gosulang.gradle;
 
 
-import org.codehaus.groovy.runtime.InvokerHelper;
 import org.gosulang.gradle.tasks.DefaultGosuSourceSet;
 import org.gosulang.gradle.tasks.GosuRuntime;
 import org.gosulang.gradle.tasks.GosuSourceSet;
@@ -15,7 +14,6 @@ import org.gradle.api.file.FileTreeElement;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.model.ObjectFactory;
-import org.gradle.api.plugins.Convention;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.reporting.ReportingExtension;
 import org.gradle.api.specs.Spec;
@@ -87,10 +85,17 @@ public class GosuBasePlugin implements Plugin<Project> {
  private void configureSourceSetDefaults() {
      javaPluginExtension(_project).getSourceSets().all(sourceSet -> {
       DefaultGosuSourceSet gosuSourceSet = new DefaultGosuSourceSet(sourceSet.getName(), _objectFactory);
-     //have to be revisit to avoid using the covention here
-      Convention sourceSetConvention = (Convention) InvokerHelper.getProperty(sourceSet, "convention");
-      sourceSetConvention.getPlugins().put("gosu", gosuSourceSet);
-  //    sourceSet.getExtensions().add(SourceDirectorySet.class, "gosu", gosuSourceSet.getGosu()); //alternative but it's not working
+      // org.gradle.api.plugins.Convention is removed in Gradle 9.0. Register the *SourceDirectorySet*
+      // itself as the "gosu" extension, matching exactly how Gradle's own current GroovyBasePlugin/
+      // ScalaBasePlugin attach their language sources (e.g. sourceSet.getExtensions().add(
+      // GroovySourceDirectorySet.class, "groovy", groovySource)). This matters because Gradle's
+      // extension-shorthand DSL (`gosu { ... }` inside a sourceSet block, or a bare `sourceSet.gosu`
+      // property read) delegates directly to the registered extension OBJECT, not through any
+      // custom method our own GosuSourceSet interface might define under the same name. Registering
+      // the wrapper GosuSourceSet instance (first attempt) broke `gosu { srcDir(...) }` /
+      // `gosu.srcDirs` DSL usage because those calls resolved against the wrapper object, which has
+      // no such methods/properties (only its nested getGosu() SourceDirectorySet does).
+      sourceSet.getExtensions().add(SourceDirectorySet.class, "gosu", gosuSourceSet.getGosu());
       gosuSourceSet.getGosu().srcDir("src/" + sourceSet.getName() + "/gosu");
       // Exclude gosu sources from this source set's resources with a *serializable* Spec, so the filter — and
       // therefore every consumer's ProcessResources task — is configuration-cache compatible. The

--- a/src/main/java/org/gosulang/gradle/GosuPlugin.java
+++ b/src/main/java/org/gosulang/gradle/GosuPlugin.java
@@ -1,12 +1,10 @@
 package org.gosulang.gradle;
 
-import org.codehaus.groovy.runtime.InvokerHelper;
 import org.gosulang.gradle.tasks.GosuRuntime;
-import org.gosulang.gradle.tasks.GosuSourceSet;
 import org.gosulang.gradle.tasks.gosudoc.GosuDoc;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.plugins.Convention;
+import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.SourceSet;
@@ -46,8 +44,11 @@ public class GosuPlugin implements Plugin<Project> {
 
  private void configureGosuDoc( final Project project ) {
      SourceSet mainSourceSet = javaPluginExtension(project).getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME);
-     Convention sourceSetConvention = (Convention) InvokerHelper.getProperty(mainSourceSet, "convention");
-     GosuSourceSet gosuSourceSet = sourceSetConvention.getPlugin(GosuSourceSet.class);
+     // Look up by name, not getByType(SourceDirectorySet.class): the "gosu" extension is registered
+     // as a plain SourceDirectorySet (see GosuBasePlugin), and getByType would throw on ambiguity if
+     // another language plugin (e.g. groovy, scala) registered its own SourceDirectorySet-typed
+     // extension on the same source set.
+     SourceDirectorySet gosuSource = (SourceDirectorySet) mainSourceSet.getExtensions().getByName("gosu");
 
      TaskProvider<GosuDoc> gosuDoc = project.getTasks().register(GOSUDOC_TASK_NAME, GosuDoc.class, t -> {
         t.setDescription("Generates Gosudoc API documentation for the main source code.");
@@ -55,7 +56,7 @@ public class GosuPlugin implements Plugin<Project> {
         // JvmFeatureInternal mainFeature = JavaPluginHelper.getJavaComponent(project).getMainFeature();//alternative approach but needs to be tested
         // gosuDoc.setClasspath(mainFeature.getSourceSet().getOutput().plus(mainFeature.getSourceSet().getCompileClasspath()));
         t.setClasspath(mainSourceSet.getOutput().plus(mainSourceSet.getCompileClasspath()));
-        t.setSource(gosuSourceSet.getGosu());
+        t.setSource(gosuSource);
     });
   }
 

--- a/src/main/java/org/gosulang/gradle/tasks/DefaultGosuSourceSet.java
+++ b/src/main/java/org/gosulang/gradle/tasks/DefaultGosuSourceSet.java
@@ -5,11 +5,11 @@ import org.gradle.api.Action;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.SourceSet;
-import org.gradle.util.ConfigureUtil;
-import org.gradle.util.GUtil;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class DefaultGosuSourceSet implements GosuSourceSet {
 
@@ -19,6 +19,45 @@ public class DefaultGosuSourceSet implements GosuSourceSet {
   private static final List<String> _gosuAndJavaExtensions = Arrays.asList("**/*.java", "**/*.gs", "**/*.gsx", "**/*.gst", "**/*.gsp");
   private static final List<String> _gosuExtensionsOnly = _gosuAndJavaExtensions.subList(1, _gosuAndJavaExtensions.size());
 
+  // Ported from Gradle's org.gradle.util.internal.GUtil#toWords (Apache License 2.0:
+  // https://github.com/gradle/gradle/blob/master/platforms/core-runtime/base-services/src/main/java/org/gradle/util/internal/GUtil.java),
+  // since org.gradle.util.GUtil is removed in Gradle 9.0. Converts an arbitrary string to
+  // space-separated words, e.g. camelCase -> camel case, with-separators -> with separators.
+  private static final Pattern UPPER_LOWER = Pattern.compile("(?m)([A-Z]*)([a-z0-9]*)");
+
+  private static String toWords(String string) {
+    StringBuilder builder = new StringBuilder();
+    int pos = 0;
+    Matcher matcher = UPPER_LOWER.matcher(string);
+    while (pos < string.length()) {
+      matcher.find(pos);
+      if (matcher.end() == pos) {
+        // Not looking at a match
+        pos++;
+        continue;
+      }
+      if (builder.length() > 0) {
+        builder.append(' ');
+      }
+      String group1 = matcher.group(1).toLowerCase();
+      String group2 = matcher.group(2);
+      if (group2.length() == 0) {
+        builder.append(group1);
+      } else {
+        if (group1.length() > 1) {
+          builder.append(group1, 0, group1.length() - 1);
+          builder.append(' ');
+          builder.append(group1.charAt(group1.length() - 1));
+        } else {
+          builder.append(group1);
+        }
+        builder.append(group2);
+      }
+      pos = matcher.end();
+    }
+    return builder.toString();
+  }
+
   private final String name;
   private final String baseName;
   private final String displayName;
@@ -27,7 +66,7 @@ public class DefaultGosuSourceSet implements GosuSourceSet {
 
     this.name = name;
     this.baseName = name.equals(SourceSet.MAIN_SOURCE_SET_NAME) ? "" : name.toUpperCase();
-    displayName = GUtil.toWords(this.name);
+    displayName = toWords(this.name);
     _gosu = objectFacotry.sourceDirectorySet("gosu", displayName + " Gosu source");
     _gosu.getFilter().include(_gosuAndJavaExtensions);
     _allGosu = objectFacotry.sourceDirectorySet("gosu", displayName + " Gosu source");
@@ -54,8 +93,14 @@ public class DefaultGosuSourceSet implements GosuSourceSet {
   }
 
   @Override
-  public GosuSourceSet gosu( Closure configureClosure ) {
-    ConfigureUtil.configure(configureClosure, getGosu());
+  public GosuSourceSet gosu(Closure<?> configureClosure) {
+    // Replicates org.gradle.util.ConfigureUtil#configure's DELEGATE_FIRST behavior (removed in
+    // Gradle 9.0) without depending on it: setting the delegate + resolve strategy lets
+    // DSL-style calls inside the closure body (e.g. `srcDir 'foo'`) resolve against the
+    // SourceDirectorySet target rather than the closure's original owner/scope.
+    configureClosure.setDelegate(getGosu());
+    configureClosure.setResolveStrategy(Closure.DELEGATE_FIRST);
+    configureClosure.call(getGosu());
     return this;
   }
 

--- a/src/main/java/org/gosulang/gradle/tasks/GosuRuntime.java
+++ b/src/main/java/org/gosulang/gradle/tasks/GosuRuntime.java
@@ -6,7 +6,7 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
-import org.gradle.util.VersionNumber;
+import org.gosulang.gradle.util.VersionNumber;
 
 import javax.annotation.Nullable;
 import java.io.File;

--- a/src/main/java/org/gosulang/gradle/tasks/GosuSourceSet.java
+++ b/src/main/java/org/gosulang/gradle/tasks/GosuSourceSet.java
@@ -16,12 +16,14 @@ public interface GosuSourceSet {
   /**
    * Configures the Gosu source for this set.
    *
-   * <p>The given closure is used to configure the {@link SourceDirectorySet} which contains the Gosu source.
+   * <p>The given closure is used to configure the {@link SourceDirectorySet} which contains the Gosu source,
+   * with the {@link SourceDirectorySet} set as the closure's delegate (resolved before the closure's
+   * owner), matching Gradle's usual Closure-configuration DSL convention.
    *
    * @param configureClosure The closure to use to configure the Gosu source.
    * @return this
    */
-  GosuSourceSet gosu(Closure configureClosure);
+  GosuSourceSet gosu(Closure<?> configureClosure);
 
   /**
    * Configures the Gosu source for this set.
@@ -31,7 +33,7 @@ public interface GosuSourceSet {
    * @param configureAction The action to use to configure the Gosu source.
    * @return this
    */
-  GosuSourceSet gosu( Action<? super SourceDirectorySet> configureAction);  
+  GosuSourceSet gosu( Action<? super SourceDirectorySet> configureAction);
   
   /**
    * All Gosu source for this source set.

--- a/src/main/java/org/gosulang/gradle/tasks/compile/CommandLineGosuCompiler.java
+++ b/src/main/java/org/gosulang/gradle/tasks/compile/CommandLineGosuCompiler.java
@@ -11,7 +11,6 @@ import org.gradle.api.tasks.compile.BaseForkOptions;
 import org.gradle.process.ExecOperations;
 import org.gradle.process.ExecResult;
 import org.gradle.process.JavaExecSpec;
-import org.gradle.util.GUtil;
 import org.gradle.api.JavaVersion;
 
 import java.io.ByteArrayOutputStream;
@@ -121,6 +120,20 @@ public class CommandLineGosuCompiler implements GosuCompiler<GosuCompileSpec> {
     spec.setJvmArgs((Iterable<?>) args); // Gradle 4.0 overloads JavaForkOptions#setJvmArgs; must upcast to Iterable<?> for backwards compatibility
   }
 
+  // Ported from Gradle's org.gradle.util.internal.GUtil#asPath (Apache License 2.0:
+  // https://github.com/gradle/gradle/blob/master/platforms/core-runtime/base-services/src/main/java/org/gradle/util/internal/GUtil.java),
+  // since org.gradle.util.GUtil is removed in Gradle 9.0.
+  private static String asPath(Iterable<File> files) {
+    StringBuilder path = new StringBuilder();
+    for (File file : files) {
+      if (path.length() > 0) {
+        path.append(File.pathSeparator);
+      }
+      path.append(file);
+    }
+    return path.toString();
+  }
+
   private File createArgFile(GosuCompileSpec spec) throws IOException {
     File tempFile = File.createTempFile(CommandLineGosuCompiler.class.getName(), "arguments", spec.getTempDir());
 
@@ -132,13 +145,13 @@ public class CommandLineGosuCompiler implements GosuCompiler<GosuCompileSpec> {
 
     // The classpath used to initialize Gosu; CommandLineCompiler will supplement this with the JRE jars
     fileOutput.add("-classpath");
-    fileOutput.add(String.join(File.pathSeparator, GUtil.asPath(spec.getClasspath())));
+    fileOutput.add(asPath(spec.getClasspath()));
 
     fileOutput.add("-d");
     fileOutput.add(spec.getDestinationDir().getAbsolutePath());
 
     fileOutput.add("-sourcepath");
-    fileOutput.add(String.join(File.pathSeparator, GUtil.asPath(spec.getSourceRoots())));
+    fileOutput.add(asPath(spec.getSourceRoots()));
 
     if(!spec.getCompileOptions().isWarnings()) {
       fileOutput.add("-nowarn");

--- a/src/main/java/org/gosulang/gradle/tasks/compile/GosuCompileOptions.java
+++ b/src/main/java/org/gosulang/gradle/tasks/compile/GosuCompileOptions.java
@@ -6,7 +6,10 @@ import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.compile.BaseForkOptions;
 
-public class GosuCompileOptions {
+import java.io.Serializable;
+
+public class GosuCompileOptions implements Serializable {
+  private static final long serialVersionUID = 0;
 
   //for some reason related to Java reflection, we need to name these private fields exactly like their getters/setters (no leading '_')
   private boolean checkedArithmetic = false;

--- a/src/main/java/org/gosulang/gradle/tasks/compile/GosuCompileOptions.java
+++ b/src/main/java/org/gosulang/gradle/tasks/compile/GosuCompileOptions.java
@@ -4,10 +4,9 @@ import org.gradle.api.tasks.Console;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
-import org.gradle.api.tasks.compile.AbstractOptions;
 import org.gradle.api.tasks.compile.BaseForkOptions;
 
-public class GosuCompileOptions extends AbstractOptions {
+public class GosuCompileOptions {
 
   //for some reason related to Java reflection, we need to name these private fields exactly like their getters/setters (no leading '_')
   private boolean checkedArithmetic = false;

--- a/src/main/java/org/gosulang/gradle/tasks/gosudoc/GosuDocOptions.java
+++ b/src/main/java/org/gosulang/gradle/tasks/gosudoc/GosuDocOptions.java
@@ -4,10 +4,9 @@ import org.gradle.api.tasks.Console;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
-import org.gradle.api.tasks.compile.AbstractOptions;
 import org.gradle.api.tasks.compile.BaseForkOptions;
 
-public class GosuDocOptions extends AbstractOptions {
+public class GosuDocOptions {
 
   //for some reason related to Java reflection, we need to name these private fields exactly like their getters/setters (no leading '_')
   private String title;

--- a/src/main/java/org/gosulang/gradle/tasks/gosudoc/GosuDocOptions.java
+++ b/src/main/java/org/gosulang/gradle/tasks/gosudoc/GosuDocOptions.java
@@ -6,7 +6,10 @@ import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.compile.BaseForkOptions;
 
-public class GosuDocOptions {
+import java.io.Serializable;
+
+public class GosuDocOptions implements Serializable {
+  private static final long serialVersionUID = 0;
 
   //for some reason related to Java reflection, we need to name these private fields exactly like their getters/setters (no leading '_')
   private String title;

--- a/src/main/java/org/gosulang/gradle/util/VersionNumber.java
+++ b/src/main/java/org/gosulang/gradle/util/VersionNumber.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gosulang.gradle.util;
+
+import javax.annotation.Nullable;
+import java.util.Comparator;
+import java.util.Objects;
+
+/**
+ * Ported from Gradle's {@code org.gradle.util.VersionNumber}
+ * (https://github.com/gradle/gradle/blob/v8.6.0/subprojects/core/src/main/java/org/gradle/util/VersionNumber.java),
+ * which Gradle removes entirely in Gradle 9.0. Modified from the original: package renamed;
+ * Guava usages ({@code com.google.common.base.Objects}, {@code com.google.common.collect.Ordering})
+ * replaced with {@code java.util} equivalents; Gradle-internal deprecation-logging removed.
+ * Behavior is otherwise unchanged.
+ */
+public class VersionNumber implements Comparable<VersionNumber> {
+
+    private static final DefaultScheme DEFAULT_SCHEME = new DefaultScheme();
+    private static final SchemeWithPatchVersion PATCH_SCHEME = new SchemeWithPatchVersion();
+    public static final VersionNumber UNKNOWN = version(0);
+
+    private final int major;
+    private final int minor;
+    private final int micro;
+    private final int patch;
+    private final String qualifier;
+    private final AbstractScheme scheme;
+
+    public VersionNumber(int major, int minor, int micro, @Nullable String qualifier) {
+        this(major, minor, micro, 0, qualifier, DEFAULT_SCHEME);
+    }
+
+    public VersionNumber(int major, int minor, int micro, int patch, @Nullable String qualifier) {
+        this(major, minor, micro, patch, qualifier, PATCH_SCHEME);
+    }
+
+    private VersionNumber(int major, int minor, int micro, int patch, @Nullable String qualifier, AbstractScheme scheme) {
+        this.major = major;
+        this.minor = minor;
+        this.micro = micro;
+        this.patch = patch;
+        this.qualifier = qualifier;
+        this.scheme = scheme;
+    }
+
+    public int getMajor() {
+        return major;
+    }
+
+    public int getMinor() {
+        return minor;
+    }
+
+    public int getMicro() {
+        return micro;
+    }
+
+    public int getPatch() {
+        return patch;
+    }
+
+    @Nullable
+    public String getQualifier() {
+        return qualifier;
+    }
+
+    public VersionNumber getBaseVersion() {
+        return new VersionNumber(major, minor, micro, patch, null, scheme);
+    }
+
+    @Override
+    public int compareTo(VersionNumber other) {
+        if (major != other.major) {
+            return major - other.major;
+        }
+        if (minor != other.minor) {
+            return minor - other.minor;
+        }
+        if (micro != other.micro) {
+            return micro - other.micro;
+        }
+        if (patch != other.patch) {
+            return patch - other.patch;
+        }
+        return Comparator.<String>nullsLast(Comparator.naturalOrder()).compare(toLowerCase(qualifier), toLowerCase(other.qualifier));
+    }
+
+    @Override
+    public boolean equals(@Nullable Object other) {
+        return other instanceof VersionNumber && compareTo((VersionNumber) other) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = major;
+        result = 31 * result + minor;
+        result = 31 * result + micro;
+        result = 31 * result + patch;
+        result = 31 * result + Objects.hashCode(qualifier);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return scheme.format(this);
+    }
+
+    public static VersionNumber version(int major) {
+        return version(major, 0);
+    }
+
+    public static VersionNumber version(int major, int minor) {
+        return new VersionNumber(major, minor, 0, 0, null, DEFAULT_SCHEME);
+    }
+
+    /**
+     * Returns the default MAJOR.MINOR.MICRO-QUALIFIER scheme.
+     */
+    public static Scheme scheme() {
+        return DEFAULT_SCHEME;
+    }
+
+    /**
+     * Returns the MAJOR.MINOR.MICRO.PATCH-QUALIFIER scheme.
+     */
+    public static Scheme withPatchNumber() {
+        return PATCH_SCHEME;
+    }
+
+    public static VersionNumber parse(String versionString) {
+        return DEFAULT_SCHEME.parse(versionString);
+    }
+
+    @Nullable
+    private String toLowerCase(@Nullable String string) {
+        return string == null ? null : string.toLowerCase();
+    }
+
+    /**
+     * Returns the version number scheme.
+     */
+    public interface Scheme {
+        VersionNumber parse(String value);
+
+        String format(VersionNumber versionNumber);
+    }
+
+    private abstract static class AbstractScheme implements Scheme {
+        final int depth;
+
+        protected AbstractScheme(int depth) {
+            this.depth = depth;
+        }
+
+        @Override
+        public VersionNumber parse(@Nullable String versionString) {
+            if (versionString == null || versionString.length() == 0) {
+                return UNKNOWN;
+            }
+            Scanner scanner = new Scanner(versionString);
+
+            int major = 0;
+            int minor = 0;
+            int micro = 0;
+            int patch = 0;
+
+            if (!scanner.hasDigit()) {
+                return UNKNOWN;
+            }
+            major = scanner.scanDigit();
+            if (scanner.isSeparatorAndDigit('.')) {
+                scanner.skipSeparator();
+                minor = scanner.scanDigit();
+                if (scanner.isSeparatorAndDigit('.')) {
+                    scanner.skipSeparator();
+                    micro = scanner.scanDigit();
+                    if (depth > 3 && scanner.isSeparatorAndDigit('.', '_')) {
+                        scanner.skipSeparator();
+                        patch = scanner.scanDigit();
+                    }
+                }
+            }
+
+            if (scanner.isEnd()) {
+                return new VersionNumber(major, minor, micro, patch, null, this);
+            }
+
+            if (scanner.isQualifier()) {
+                scanner.skipSeparator();
+                return new VersionNumber(major, minor, micro, patch, scanner.remainder(), this);
+            }
+
+            return UNKNOWN;
+        }
+
+        private static class Scanner {
+            int pos;
+            final String str;
+
+            private Scanner(String string) {
+                this.str = string;
+            }
+
+            boolean hasDigit() {
+                return pos < str.length() && Character.isDigit(str.charAt(pos));
+            }
+
+            boolean isSeparatorAndDigit(char... separators) {
+                return pos < str.length() - 1 && oneOf(separators) && Character.isDigit(str.charAt(pos + 1));
+            }
+
+            private boolean oneOf(char... separators) {
+                char current = str.charAt(pos);
+                for (int i = 0; i < separators.length; i++) {
+                    char separator = separators[i];
+                    if (current == separator) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            boolean isQualifier() {
+                return pos < str.length() - 1 && oneOf('.', '-');
+            }
+
+            int scanDigit() {
+                int start = pos;
+                while (hasDigit()) {
+                    pos++;
+                }
+                return Integer.parseInt(str.substring(start, pos));
+            }
+
+            public boolean isEnd() {
+                return pos == str.length();
+            }
+
+            public void skipSeparator() {
+                pos++;
+            }
+
+            @Nullable
+            public String remainder() {
+                return pos == str.length() ? null : str.substring(pos);
+            }
+        }
+    }
+
+    private static class DefaultScheme extends AbstractScheme {
+        private static final String VERSION_TEMPLATE = "%d.%d.%d%s";
+
+        public DefaultScheme() {
+            super(3);
+        }
+
+        @Override
+        public String format(VersionNumber versionNumber) {
+            return String.format(VERSION_TEMPLATE, versionNumber.major, versionNumber.minor, versionNumber.micro, versionNumber.qualifier == null ? "" : "-" + versionNumber.qualifier);
+        }
+    }
+
+    private static class SchemeWithPatchVersion extends AbstractScheme {
+        private static final String VERSION_TEMPLATE = "%d.%d.%d.%d%s";
+
+        private SchemeWithPatchVersion() {
+            super(4);
+        }
+
+        @Override
+        public String format(VersionNumber versionNumber) {
+            return String.format(VERSION_TEMPLATE, versionNumber.major, versionNumber.minor, versionNumber.micro, versionNumber.patch, versionNumber.qualifier == null ? "" : "-" + versionNumber.qualifier);
+        }
+    }
+
+}

--- a/src/test/groovy/org/gosulang/gradle/functional/AbstractGosuPluginSpecification.groovy
+++ b/src/test/groovy/org/gosulang/gradle/functional/AbstractGosuPluginSpecification.groovy
@@ -1,6 +1,6 @@
 package org.gosulang.gradle.functional
 
-import org.gradle.util.VersionNumber
+import org.gosulang.gradle.util.VersionNumber
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Shared

--- a/src/test/groovy/org/gosulang/gradle/functional/AdditionalScriptExtensionsTest.groovy
+++ b/src/test/groovy/org/gosulang/gradle/functional/AdditionalScriptExtensionsTest.groovy
@@ -2,7 +2,7 @@ package org.gosulang.gradle.functional
 
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
-import org.gradle.util.VersionNumber
+import org.gosulang.gradle.util.VersionNumber
 import spock.lang.Unroll
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS

--- a/src/test/groovy/org/gosulang/gradle/functional/ExclusionFilterTest.groovy
+++ b/src/test/groovy/org/gosulang/gradle/functional/ExclusionFilterTest.groovy
@@ -2,7 +2,7 @@ package org.gosulang.gradle.functional
 
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
-import org.gradle.util.VersionNumber
+import org.gosulang.gradle.util.VersionNumber
 import spock.lang.Unroll
 
 import static org.gradle.testkit.runner.TaskOutcome.NO_SOURCE

--- a/src/test/groovy/org/gosulang/gradle/functional/GosuPluginVariantTest.groovy
+++ b/src/test/groovy/org/gosulang/gradle/functional/GosuPluginVariantTest.groovy
@@ -54,7 +54,7 @@ class GosuPluginVariantTest extends AbstractGosuPluginSpecification {
     Attributes
         - org.gradle.category            = library
         - org.gradle.dependency.bundling = external
-        - org.gradle.jvm.version         = 11
+        - org.gradle.jvm.version         = 21
         - org.gradle.libraryelements     = classes
         - org.gradle.usage               = java-runtime
     Artifacts
@@ -87,7 +87,7 @@ class GosuPluginVariantTest extends AbstractGosuPluginSpecification {
     Attributes
         - org.gradle.category            = library
         - org.gradle.dependency.bundling = external
-        - org.gradle.jvm.version         = 11
+        - org.gradle.jvm.version         = 21
         - org.gradle.libraryelements     = classes
         - org.gradle.usage               = java-api
     Artifacts

--- a/src/test/groovy/org/gosulang/gradle/functional/IncrementalCompilationTest.groovy
+++ b/src/test/groovy/org/gosulang/gradle/functional/IncrementalCompilationTest.groovy
@@ -4,7 +4,7 @@ import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.gradle.testkit.runner.UnexpectedBuildSuccess
-import org.gradle.util.VersionNumber
+import org.gosulang.gradle.util.VersionNumber
 import spock.lang.Unroll
 
 import java.util.regex.Pattern

--- a/src/test/groovy/org/gosulang/gradle/functional/LocalBuildCacheTest.groovy
+++ b/src/test/groovy/org/gosulang/gradle/functional/LocalBuildCacheTest.groovy
@@ -2,7 +2,7 @@ package org.gosulang.gradle.functional
 
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
-import org.gradle.util.VersionNumber
+import org.gosulang.gradle.util.VersionNumber
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder

--- a/src/test/groovy/org/gosulang/gradle/functional/SourceSetsModificationTest.groovy
+++ b/src/test/groovy/org/gosulang/gradle/functional/SourceSetsModificationTest.groovy
@@ -2,7 +2,7 @@ package org.gosulang.gradle.functional
 
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
-import org.gradle.util.VersionNumber
+import org.gosulang.gradle.util.VersionNumber
 import spock.lang.Unroll
 
 import static org.gradle.testkit.runner.TaskOutcome.NO_SOURCE

--- a/src/test/groovy/org/gosulang/gradle/unit/GosuRuntimeTest.groovy
+++ b/src/test/groovy/org/gosulang/gradle/unit/GosuRuntimeTest.groovy
@@ -3,7 +3,7 @@ package org.gosulang.gradle.unit
 import org.gosulang.gradle.GosuBasePlugin
 import org.gradle.api.GradleException
 import org.gradle.testfixtures.ProjectBuilder
-import org.gradle.util.VersionNumber
+import org.gosulang.gradle.util.VersionNumber
 import spock.lang.Specification
 
 class GosuRuntimeTest extends Specification {

--- a/src/test/groovy/org/gosulang/gradle/util/VersionNumberTest.groovy
+++ b/src/test/groovy/org/gosulang/gradle/util/VersionNumberTest.groovy
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gosulang.gradle.util
+
+import spock.lang.Specification
+
+/**
+ * Ported from Gradle's org.gradle.util.VersionNumberTest
+ * (https://github.com/gradle/gradle/blob/v8.6.0/subprojects/core/src/test/groovy/org/gradle/util/VersionNumberTest.groovy),
+ * adapted to test this project's own {@link VersionNumber} port instead of Gradle's (removed
+ * in Gradle 9.0). The "equality" test replaces Gradle-internal {@code Matchers.strictlyEqual}
+ * (not available outside Gradle's own test-fixtures) with equivalent plain equals/hashCode
+ * assertions; all other test cases are unchanged in substance.
+ */
+class VersionNumberTest extends Specification {
+    def "construction"() {
+        expect:
+        VersionNumber.version(5) == new VersionNumber(5, 0, 0, null)
+    }
+
+    def "parsing"() {
+        expect:
+        VersionNumber.parse("1") == new VersionNumber(1, 0, 0, null)
+        VersionNumber.parse("1.0") == new VersionNumber(1, 0, 0, null)
+        VersionNumber.parse("1.0.0") == new VersionNumber(1, 0, 0, null)
+
+        VersionNumber.parse("1.2") == new VersionNumber(1, 2, 0, null)
+        VersionNumber.parse("1.2.3") == new VersionNumber(1, 2, 3, null)
+
+        VersionNumber.parse("1-rc1-SNAPSHOT") == new VersionNumber(1, 0, 0, "rc1-SNAPSHOT")
+        VersionNumber.parse("1.2-rc1-SNAPSHOT") == new VersionNumber(1, 2, 0, "rc1-SNAPSHOT")
+        VersionNumber.parse("1.2.3-rc1-SNAPSHOT") == new VersionNumber(1, 2, 3, "rc1-SNAPSHOT")
+
+        VersionNumber.parse("1.rc1-SNAPSHOT") == new VersionNumber(1, 0, 0, "rc1-SNAPSHOT")
+        VersionNumber.parse("1.2.rc1-SNAPSHOT") == new VersionNumber(1, 2, 0, "rc1-SNAPSHOT")
+        VersionNumber.parse("1.2.3.rc1-SNAPSHOT") == new VersionNumber(1, 2, 3, "rc1-SNAPSHOT")
+
+        VersionNumber.parse("11.22") == new VersionNumber(11, 22, 0, null)
+        VersionNumber.parse("11.22.33") == new VersionNumber(11, 22, 33, null)
+        VersionNumber.parse("11.22.33-eap") == new VersionNumber(11, 22, 33, "eap")
+
+        VersionNumber.parse("11.fortyfour") == new VersionNumber(11, 0, 0, "fortyfour")
+
+        VersionNumber.parse("1.0.0.0") == new VersionNumber(1, 0, 0, "0")
+        VersionNumber.parse("1.0.0.0.0.0.0") == new VersionNumber(1, 0, 0, "0.0.0.0")
+        VersionNumber.parse("1.2.3.4-rc1-SNAPSHOT") == new VersionNumber(1, 2, 3, "4-rc1-SNAPSHOT")
+        VersionNumber.parse("1.2.3.4.rc1-SNAPSHOT") == new VersionNumber(1, 2, 3, "4.rc1-SNAPSHOT")
+    }
+
+    def "parsing with patch number"() {
+        expect:
+        def defaultScheme = VersionNumber.scheme()
+        defaultScheme.parse("1") == new VersionNumber(1, 0, 0, null)
+        defaultScheme.parse("1.2") == new VersionNumber(1, 2, 0, null)
+        defaultScheme.parse("1.2.3") == new VersionNumber(1, 2, 3, null)
+        defaultScheme.parse("1.2.3-qualifier") == new VersionNumber(1, 2, 3, "qualifier")
+        defaultScheme.parse("1.2.3.4") == new VersionNumber(1, 2, 3, "4")
+
+        def patchScheme = VersionNumber.withPatchNumber()
+        patchScheme.parse("1") == new VersionNumber(1, 0, 0, null)
+        patchScheme.parse("1.2") == new VersionNumber(1, 2, 0, null)
+        patchScheme.parse("1.2.3") == new VersionNumber(1, 2, 3, null)
+        patchScheme.parse("1.2.3.4") == new VersionNumber(1, 2, 3, 4, null)
+        patchScheme.parse("1.2.3_4") == new VersionNumber(1, 2, 3, 4, null)
+        patchScheme.parse("1.2.3.4-qualifier") == new VersionNumber(1, 2, 3, 4, "qualifier")
+        patchScheme.parse("1.2.3.4.qualifier") == new VersionNumber(1, 2, 3, 4, "qualifier")
+        patchScheme.parse("1.2.3.4.5.6") == new VersionNumber(1, 2, 3, 4, "5.6")
+    }
+
+    def "unparseable version number is represented as UNKNOWN (0.0.0.0)"() {
+        expect:
+        VersionNumber.parse(null) == VersionNumber.UNKNOWN
+        VersionNumber.parse("") == VersionNumber.UNKNOWN
+        VersionNumber.parse("foo") == VersionNumber.UNKNOWN
+        VersionNumber.parse("1.") == VersionNumber.UNKNOWN
+        VersionNumber.parse("1.2.3-") == VersionNumber.UNKNOWN
+        VersionNumber.parse(".") == VersionNumber.UNKNOWN
+        VersionNumber.parse("_") == VersionNumber.UNKNOWN
+        VersionNumber.parse("-") == VersionNumber.UNKNOWN
+        VersionNumber.parse(".1") == VersionNumber.UNKNOWN
+        VersionNumber.parse("a.1") == VersionNumber.UNKNOWN
+        VersionNumber.parse("1_2") == VersionNumber.UNKNOWN
+        VersionNumber.parse("1_2_2") == VersionNumber.UNKNOWN
+        VersionNumber.parse("1.2.3_4") == VersionNumber.UNKNOWN
+    }
+
+    def "accessors"() {
+        when:
+        def version = new VersionNumber(1, 2, 3, 4, "foo")
+
+        then:
+        version.major == 1
+        version.minor == 2
+        version.micro == 3
+        version.patch == 4
+        version.qualifier == "foo"
+    }
+
+    def "string representation"() {
+        expect:
+        VersionNumber.parse("1.0").toString() == "1.0.0"
+        VersionNumber.parse("1.2.3").toString() == "1.2.3"
+        VersionNumber.parse("1.2.3.4").toString() == "1.2.3-4"
+        VersionNumber.parse("1-rc-1").toString() == "1.0.0-rc-1"
+        VersionNumber.parse("1.2.3-rc-1").toString() == "1.2.3-rc-1"
+
+        def patchScheme = VersionNumber.withPatchNumber()
+        patchScheme.parse("1").toString() == "1.0.0.0"
+        patchScheme.parse("1.2").toString() == "1.2.0.0"
+        patchScheme.parse("1.2.3").toString() == "1.2.3.0"
+        patchScheme.parse("1.2.3.4").toString() == "1.2.3.4"
+        patchScheme.parse("1.2-rc-1").toString() == "1.2.0.0-rc-1"
+    }
+
+    def "equality"() {
+        // Ported from Gradle's Matchers.strictlyEqual(...) (Gradle-internal test-fixtures,
+        // not available here) -- these assertions check the same two properties
+        // strictlyEqual does: mutual equals() and matching hashCode().
+        def version = new VersionNumber(1, 1, 1, 1, null)
+        def qualified = new VersionNumber(1, 1, 1, 1, "beta-2")
+
+        expect:
+        new VersionNumber(1, 1, 1, 1, null) == version
+        version == new VersionNumber(1, 1, 1, 1, null)
+        new VersionNumber(1, 1, 1, 1, null).hashCode() == version.hashCode()
+
+        new VersionNumber(2, 1, 1, 1, null) != version
+        new VersionNumber(1, 2, 1, 1, null) != version
+        new VersionNumber(1, 1, 2, 1, null) != version
+        new VersionNumber(1, 1, 1, 2, null) != version
+        new VersionNumber(1, 1, 1, 1, "rc") != version
+
+        new VersionNumber(1, 1, 1, 1, "beta-2") == qualified
+        qualified == new VersionNumber(1, 1, 1, 1, "beta-2")
+        new VersionNumber(1, 1, 1, 1, "beta-2").hashCode() == qualified.hashCode()
+
+        new VersionNumber(1, 1, 1, 1, "beta-3") != qualified
+    }
+
+    def "comparison"() {
+        expect:
+        (new VersionNumber(1, 1, 1, null) <=> new VersionNumber(1, 1, 1, null)) == 0
+        (new VersionNumber(1, 1, 1, null) <=> new VersionNumber(1, 1, 1, 0, null)) == 0
+
+        new VersionNumber(2, 1, 1, null) > new VersionNumber(1, 1, 1, null)
+        new VersionNumber(1, 2, 1, null) > new VersionNumber(1, 1, 1, null)
+        new VersionNumber(1, 1, 2, null) > new VersionNumber(1, 1, 1, null)
+        new VersionNumber(1, 1, 1, 2, null) > new VersionNumber(1, 1, 1, null)
+        new VersionNumber(1, 1, 1, "rc") < new VersionNumber(1, 1, 1, null)
+        new VersionNumber(1, 1, 1, "beta") > new VersionNumber(1, 1, 1, "alpha")
+        new VersionNumber(1, 1, 1, "RELEASE") > new VersionNumber(1, 1, 1, "beta")
+        new VersionNumber(1, 1, 1, "SNAPSHOT") < new VersionNumber(1, 1, 1, null)
+
+        new VersionNumber(1, 1, 1, null) < new VersionNumber(2, 1, 1, null)
+        new VersionNumber(1, 1, 1, null) < new VersionNumber(1, 2, 1, null)
+        new VersionNumber(1, 1, 1, null) < new VersionNumber(1, 1, 2, null)
+        new VersionNumber(1, 1, 1, null) > new VersionNumber(1, 1, 1, "rc")
+        new VersionNumber(1, 1, 1, "alpha") < new VersionNumber(1, 1, 1, "beta")
+        new VersionNumber(1, 1, 1, "beta") < new VersionNumber(1, 1, 1, "RELEASE")
+    }
+
+    def "base version"() {
+        expect:
+        new VersionNumber(1, 2, 3, null).baseVersion == new VersionNumber(1, 2, 3, null)
+        new VersionNumber(1, 2, 3, "beta").baseVersion == new VersionNumber(1, 2, 3, null)
+    }
+}


### PR DESCRIPTION
Build and test with JDK 21, but the plugin jar will be Java 8 compatible bytecode and API use.  Added v9.6.1 to the multiversion tests.

There are two breaking API changes, but these are minor and unlikely to affect consumers:

1. sourceSet.gosu no longer returns the GosuSourceSet wrapper — it returns the plain SourceDirectorySet directly.
2. GosuCompileOptions/GosuDocOptions no longer extends AbstractOptions — now implements Serializable directly.  This mirrors changes that Gradle made to its own classes in version 8.11.

Closes #92
Closes #94 